### PR TITLE
Add lexer warnings

### DIFF
--- a/crates/compiler/src/compilation_steps.rs
+++ b/crates/compiler/src/compilation_steps.rs
@@ -1,6 +1,7 @@
 mod add_initial_value_registrations;
 mod add_tracking_declarations;
 mod check_types;
+mod clean_up_diagnostics;
 mod create_declarations_for_tracking_nodes;
 mod early_breaks;
 mod find_tracking_nodes;
@@ -11,9 +12,11 @@ mod register_initial_variables;
 mod register_strings;
 mod resolve_deferred_type_diagnostic;
 mod validate_unique_node_names;
+
 pub(crate) use self::{
     add_initial_value_registrations::*, add_tracking_declarations::*, check_types::*,
-    create_declarations_for_tracking_nodes::*, early_breaks::*, find_tracking_nodes::*,
-    generate_code::*, get_declarations::*, parse_files::*, register_initial_variables::*,
-    register_strings::*, resolve_deferred_type_diagnostic::*, validate_unique_node_names::*,
+    clean_up_diagnostics::*, create_declarations_for_tracking_nodes::*, early_breaks::*,
+    find_tracking_nodes::*, generate_code::*, get_declarations::*, parse_files::*,
+    register_initial_variables::*, register_strings::*, resolve_deferred_type_diagnostic::*,
+    validate_unique_node_names::*,
 };

--- a/crates/compiler/src/compilation_steps/add_initial_value_registrations.rs
+++ b/crates/compiler/src/compilation_steps/add_initial_value_registrations.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use std::collections::HashSet;
 use yarn_slinger_core::prelude::*;
 use yarn_slinger_core::types::{Type, TypeFormat};
 
@@ -10,8 +9,8 @@ pub(crate) fn add_initial_value_registrations(
     // of the inputs, and create an initial value registration for
     // it.
     let Ok(compilation) = state.result.as_mut().unwrap().as_mut() else {
-        return state;
-    };
+            return state;
+        };
 
     let declarations = state
         .known_variable_declarations
@@ -21,35 +20,24 @@ pub(crate) fn add_initial_value_registrations(
 
     for declaration in declarations {
         let Some(default_value) = declaration.default_value.clone() else {
-             compilation.diagnostics.push(
-                 Diagnostic::from_message(
-                     format!("Variable declaration {} (type {}) has a null default value. This is not allowed.", declaration.name, declaration.r#type.format())));
-             continue;
-         };
+                state.diagnostics.push(
+                    Diagnostic::from_message(
+                        format!("Variable declaration {} (type {}) has a null default value. This is not allowed.", declaration.name, declaration.r#type.format())));
+                continue;
+            };
         if let Some(ref mut program) = compilation.program {
             let value = match declaration.r#type.as_ref().unwrap() {
-                Type::String => Operand::from(String::try_from(default_value).unwrap()),
-                Type::Number => Operand::from(f32::try_from(default_value).unwrap()),
-                Type::Boolean => Operand::from(bool::try_from(default_value).unwrap()),
-                _ => panic!("Cannot create initial value registration for type {}. This is a bug. Please report it at https://github.com/yarn-slinger/yarn_slinger/issues/new", declaration.r#type.format()),
-            };
+                    Type::String => Operand::from(String::try_from(default_value).unwrap()),
+                    Type::Number => Operand::from(f32::try_from(default_value).unwrap()),
+                    Type::Boolean => Operand::from(bool::try_from(default_value).unwrap()),
+                    _ => panic!("Cannot create initial value registration for type {}. This is a bug. Please report it at https://github.com/yarn-slinger/yarn_slinger/issues/new", declaration.r#type.format()),
+                };
             program
                 .initial_values
                 .insert(declaration.name.clone(), value);
         }
     }
-    compilation.declarations = state.derived_variable_declarations.clone();
-    let mut unique_diagnostics: HashSet<Diagnostic> =
-        HashSet::from_iter(state.diagnostics.clone().into_iter());
-    let mut ordered_unique_diagnostics = Vec::new();
 
-    // preserve order
-    for diagnostic in compilation.diagnostics.iter() {
-        if unique_diagnostics.contains(diagnostic) {
-            ordered_unique_diagnostics.push(diagnostic.clone());
-            unique_diagnostics.remove(diagnostic);
-        }
-    }
-    compilation.diagnostics = ordered_unique_diagnostics;
+    compilation.declarations = state.derived_variable_declarations.clone();
     state
 }

--- a/crates/compiler/src/compilation_steps/clean_up_diagnostics.rs
+++ b/crates/compiler/src/compilation_steps/clean_up_diagnostics.rs
@@ -1,0 +1,35 @@
+use crate::listeners::DiagnosticVec;
+use crate::prelude::*;
+use std::collections::HashSet;
+
+pub(crate) fn clean_up_diagnostics(mut state: CompilationIntermediate) -> CompilationIntermediate {
+    let total_diagnostics = if let Some(Ok(compilation)) = state.result.as_ref() {
+        compilation
+            .warnings
+            .iter()
+            .cloned()
+            .chain(state.diagnostics.iter().cloned())
+            .collect()
+    } else {
+        state.diagnostics.clone()
+    };
+    let mut unique_diagnostics: HashSet<Diagnostic> = HashSet::from_iter(total_diagnostics.clone());
+    let mut ordered_unique_diagnostics = Vec::new();
+
+    // preserve order
+    for diagnostic in total_diagnostics {
+        if unique_diagnostics.contains(&diagnostic) {
+            unique_diagnostics.remove(&diagnostic);
+            ordered_unique_diagnostics.push(diagnostic);
+        }
+    }
+    state.diagnostics = ordered_unique_diagnostics;
+    if state.diagnostics.has_errors() {
+        state.result = Some(Err(CompilationError {
+            diagnostics: state.diagnostics.clone(),
+        }));
+    } else if let Some(Ok(compilation)) = state.result.as_mut() {
+        compilation.warnings = state.diagnostics.clone();
+    }
+    state
+}

--- a/crates/compiler/src/compilation_steps/early_breaks.rs
+++ b/crates/compiler/src/compilation_steps/early_breaks.rs
@@ -7,9 +7,10 @@ pub(crate) fn break_on_job_with_only_strings(
         state.result = Some(Ok(Compilation {
             string_table: state.string_table.clone().into(),
             contains_implicit_string_tags: state.string_table.contains_implicit_string_tags(),
-            diagnostics: state.diagnostics.clone(),
+            warnings: state.diagnostics.clone(),
             ..Default::default()
         }));
+        state.early_break = true;
     }
     state
 }
@@ -20,10 +21,11 @@ pub(crate) fn break_on_job_with_only_declarations(
     if state.job.compilation_type == CompilationType::DeclarationsOnly {
         state.result = Some(Ok(Compilation {
             declarations: state.derived_variable_declarations.clone(),
-            diagnostics: state.diagnostics.clone(),
+            warnings: state.diagnostics.clone(),
             file_tags: state.file_tags.clone(),
             ..Default::default()
         }));
+        state.early_break = true;
     }
     state
 }

--- a/crates/compiler/src/compiler/utils.rs
+++ b/crates/compiler/src/compiler/utils.rs
@@ -223,5 +223,21 @@ mod tests {
         };
         let _parsed_file = parse_syntax_tree(&mixed_indentation_input, &mut diagnostics);
         assert_eq!(1, diagnostics.len());
+        assert_eq!(
+            Diagnostic::from_message("Indentation contains tabs and spaces")
+                .with_context("\t   ")
+                .with_file_name("test.yarn")
+                .with_range(
+                    Position {
+                        line: 3,
+                        character: 0
+                    }..=Position {
+                        line: 3,
+                        character: 4
+                    }
+                )
+                .with_severity(DiagnosticSeverity::Warning),
+            diagnostics[0]
+        );
     }
 }

--- a/crates/compiler/src/compiler/utils.rs
+++ b/crates/compiler/src/compiler/utils.rs
@@ -204,3 +204,24 @@ pub(crate) fn get_declarations_from_library(library: &Library) -> Vec<Declaratio
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warns_about_mixed_indentation() {
+        let mut diagnostics = Vec::new();
+        let mixed_indentation_input = File {
+            file_name: "test.yarn".to_owned(),
+            source: "title: Start
+---
+-> Option 1
+\t   Nice.
+==="
+            .to_owned(),
+        };
+        let _parsed_file = parse_syntax_tree(&mixed_indentation_input, &mut diagnostics);
+        assert_eq!(1, diagnostics.len());
+    }
+}

--- a/crates/compiler/src/listeners/error_listener/diagnostic.rs
+++ b/crates/compiler/src/listeners/error_listener/diagnostic.rs
@@ -83,7 +83,6 @@ impl Display for Diagnostic {
         let annotation_type = match self.severity {
             DiagnosticSeverity::Error => AnnotationType::Error,
             DiagnosticSeverity::Warning => AnnotationType::Warning,
-            DiagnosticSeverity::Info => AnnotationType::Info,
         };
         let snippet = Snippet {
             title: Some(Annotation {
@@ -140,6 +139,10 @@ impl DiagnosticVec for Vec<Diagnostic> {
 }
 
 /// The severity of the issue.
+///
+/// ## Implementation notes
+///
+/// The `Info` variant was not implemented because it was unused.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, strum_macros::Display)]
 pub enum DiagnosticSeverity {
     /// An error.
@@ -149,15 +152,9 @@ pub enum DiagnosticSeverity {
     #[default]
     Error,
 
-    /// An warning.
+    /// A warning.
     ///
     /// Warnings represent possible problems that the user should fix,
     /// but do not cause the compilation process to fail.
     Warning,
-
-    /// An informational diagnostic.
-    ///
-    /// Infos represent possible issues or steps that the user may wish
-    /// to fix, but are unlikely to cause problems.
-    Info,
 }

--- a/crates/compiler/src/listeners/error_listener/diagnostic.rs
+++ b/crates/compiler/src/listeners/error_listener/diagnostic.rs
@@ -129,6 +129,16 @@ impl Display for Diagnostic {
     }
 }
 
+pub trait DiagnosticVec {
+    fn has_errors(&self) -> bool;
+}
+
+impl DiagnosticVec for Vec<Diagnostic> {
+    fn has_errors(&self) -> bool {
+        self.iter().any(|d| d.severity == DiagnosticSeverity::Error)
+    }
+}
+
 /// The severity of the issue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, strum_macros::Display)]
 pub enum DiagnosticSeverity {

--- a/crates/compiler/src/output.rs
+++ b/crates/compiler/src/output.rs
@@ -15,6 +15,11 @@ mod string_info;
 /// The result of a compilation.
 ///
 /// Instances of this struct are produced as a result of supplying a [`CompilationJob`] to [`compile`].
+/// 
+/// ## Implementation Notes
+/// 
+/// In contrast to the original implementation, where this struct was called a `CompilationResult`, we return
+/// an actual [`Result`], so this type is guaranteed to only hold warnings as opposed to all diagnostics.
 #[derive(Debug, Clone, Default)]
 pub struct Compilation {
     /// The compiled Yarn program that the [`Compiler`] produced.
@@ -64,7 +69,12 @@ pub struct Compilation {
     pub file_tags: HashMap<String, Vec<String>>,
 
     /// The collection of [`Diagnostic`] objects that
-    /// describe non-fatal problems in the source code.
+    /// describe possible problems that the user should fix,
+    /// but do not cause the compilation process to fail.
+    /// 
+    /// All diagnostics in this collection have a severity of [`DiagnosticSeverity::Warning`].
+    /// If there was an error during compilation, the compilation returns an [`Err`] variant containing
+    /// error diagnostics instead of this [`Compilation`].
     pub warnings: Vec<Diagnostic>,
 
     /// The collection of [`DebugInfo`] objects for each node in [`Program`].

--- a/crates/compiler/src/output.rs
+++ b/crates/compiler/src/output.rs
@@ -64,12 +64,8 @@ pub struct Compilation {
     pub file_tags: HashMap<String, Vec<String>>,
 
     /// The collection of [`Diagnostic`] objects that
-    /// describe problems in the source code.
-    ///
-    /// If the compiler encounters errors while compiling source code, the
-    /// [`CompilationResult`] it produces will have a [`Program`] value of [`None`]. To help figure out
-    /// what the error is, users should consult the contents of this field.
-    pub diagnostics: Vec<Diagnostic>,
+    /// describe non-fatal problems in the source code.
+    pub warnings: Vec<Diagnostic>,
 
     /// The collection of [`DebugInfo`] objects for each node in [`Program`].
     pub debug_info: HashMap<String, DebugInfo>,
@@ -91,7 +87,7 @@ impl Compilation {
             programs.push(compilation.program.unwrap());
             declarations.extend(compilation.declarations);
             tags.extend(compilation.file_tags);
-            diagnostics.extend(compilation.diagnostics);
+            diagnostics.extend(compilation.warnings);
             node_debug_infos.extend(compilation.debug_info);
         }
         let combined_program = Program::combine(programs);
@@ -103,7 +99,7 @@ impl Compilation {
             debug_info: node_debug_infos,
             contains_implicit_string_tags,
             file_tags: tags,
-            diagnostics,
+            warnings: diagnostics,
         }
     }
 }

--- a/crates/compiler/src/output/declaration.rs
+++ b/crates/compiler/src/output/declaration.rs
@@ -6,7 +6,7 @@
 
 use crate::parser_rule_context_ext::ParserRuleContextExt;
 use crate::prelude::{ActualTokenStream, Diagnostic};
-use antlr_rust::token::{CommonToken, Token};
+use antlr_rust::token::Token;
 use std::fmt::{Debug, Display};
 use std::ops::RangeInclusive;
 use yarn_slinger_core::prelude::convertible::Convertible;
@@ -193,26 +193,6 @@ pub(crate) trait ParserRuleContextExtRangeSource<'input>:
 }
 
 impl<'input, T: ParserRuleContextExt<'input>> ParserRuleContextExtRangeSource<'input> for T {}
-
-pub(crate) trait TokenRangeSource<'input>: Token {
-    fn range(&self) -> RangeInclusive<Position>;
-}
-
-impl<'input> TokenRangeSource<'input> for CommonToken<'input> {
-    fn range(&self) -> RangeInclusive<Position> {
-        let line = self.get_line() as usize - 1;
-        let start_character = self.get_column() as usize;
-        let start = Position {
-            line,
-            character: start_character,
-        };
-        let stop = Position {
-            line,
-            character: start_character + self.get_text().len() - 1,
-        };
-        start..=stop
-    }
-}
 
 impl Display for DeclarationSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/compiler/src/parser/indent_aware_lexer.rs
+++ b/crates/compiler/src/parser/indent_aware_lexer.rs
@@ -32,6 +32,10 @@ type YarnSpinnerLexer = ();
 antlr_rust::tid! { impl<'input, Input> TidAble<'input> for IndentAwareYarnSpinnerLexer<'input, Input> where Input:CharStream<From<'input>> }
 
 /// A Lexer subclass that detects newlines and generates indent and dedent tokens accordingly.
+///
+/// ## Implementation notes
+///
+/// In contrast to the original implementation, the warnings emitted by this lexer are actually respected in the diagnostics.
 pub struct IndentAwareYarnSpinnerLexer<
     'input,
     Input: CharStream<From<'input>>,

--- a/crates/compiler/src/visitors/declaration_visitor.rs
+++ b/crates/compiler/src/visitors/declaration_visitor.rs
@@ -243,7 +243,7 @@ mod tests {
         })
         .unwrap();
 
-        assert!(result.diagnostics.is_empty());
+        assert!(result.warnings.is_empty());
         assert_eq!(result.declarations.len(), 4);
         assert_eq!(
             result.declarations[0],

--- a/crates/compiler/src/visitors/node_tracking_visitor.rs
+++ b/crates/compiler/src/visitors/node_tracking_visitor.rs
@@ -134,7 +134,7 @@ tracking: always
     }
 
     fn process_input(input: &str) -> NodeTrackingVisitor {
-        let lexer = YarnSpinnerLexer::new(InputStream::new(input));
+        let lexer = YarnSpinnerLexer::new(InputStream::new(input), "input.yarn".to_owned());
         let mut parser = YarnSpinnerParser::new(CommonTokenStream::new(lexer));
         let tree = parser.dialogue().unwrap();
         let mut visitor = NodeTrackingVisitor::new();

--- a/crates/compiler/src/visitors/string_table_generator_visitor.rs
+++ b/crates/compiler/src/visitors/string_table_generator_visitor.rs
@@ -217,7 +217,7 @@ A line with {$many} many {(1 -(1 * 2))}{$cool} expressions
     }
 
     fn process_input(input: &str) -> String {
-        let lexer = YarnSpinnerLexer::new(InputStream::new(input));
+        let lexer = YarnSpinnerLexer::new(InputStream::new(input), "input.yarn".to_owned());
         let mut parser = YarnSpinnerParser::new(CommonTokenStream::new(lexer));
         let line_formatted_text = parser
             .dialogue()

--- a/crates/compiler/tests/indent_aware_lexer.rs
+++ b/crates/compiler/tests/indent_aware_lexer.rs
@@ -63,7 +63,8 @@ This is the one and only line
 ===";
 
     let generated_lexer = GeneratedYarnSpinnerLexer::new(InputStream::new(MINIMAL_INPUT));
-    let indent_aware_lexer = IndentAwareYarnSpinnerLexer::new(InputStream::new(MINIMAL_INPUT));
+    let indent_aware_lexer =
+        IndentAwareYarnSpinnerLexer::new(InputStream::new(MINIMAL_INPUT), "input.yarn".to_owned());
 
     let mut reference_token_stream = CommonTokenStream::new(generated_lexer);
     let mut indent_aware_token_stream = CommonTokenStream::new(indent_aware_lexer);
@@ -98,6 +99,7 @@ This is the one and only line
 
 #[test]
 fn correctly_indents_and_dedents_with_token() {
+    // Careful: IDE's love to break the following significant whitespace!
     let option_indentation_relevant_input: &str = "title: Start
 ---
 -> Option 1
@@ -113,8 +115,10 @@ fn correctly_indents_and_dedents_with_token() {
     
 ===";
 
-    let indent_aware_lexer =
-        IndentAwareYarnSpinnerLexer::new(InputStream::new(option_indentation_relevant_input));
+    let indent_aware_lexer = IndentAwareYarnSpinnerLexer::new(
+        InputStream::new(option_indentation_relevant_input),
+        "input.yarn".to_owned(),
+    );
 
     let mut indent_aware_token_stream = CommonTokenStream::new(indent_aware_lexer);
 


### PR DESCRIPTION
- Resolves #48 
- Places lexer warnings in diagnostics.
- Add a test reporting mixed whitespace.
- Makes sure that successful `Compilation`s never contain any errors but only warnings at most.
- Removes the `Info` diagnostic severity because it is unused.