### PR TITLE
Implement Test Base and Refactor Dialogue API for Multithreaded Contexts

### DIFF
--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,14 +1,11 @@
 use std::io::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() -> Result<()> {
-    let include_dir_path: PathBuf = ["..", "..", "third-party", "YarnSpinner", "YarnSpinner"]
-        .iter()
-        .collect();
-    let include_dir = include_dir_path.to_str().unwrap();
-    let proto_file_path: PathBuf = [include_dir, "yarn_spinner.proto"].iter().collect();
-    let proto_file = proto_file_path.to_str().unwrap();
-    println!("cargo:rerun-if-changed={proto_file}");
+    let include_dir: &Path = "../../third-party/YarnSpinner/YarnSpinner".as_ref();
+    let proto_file: PathBuf = include_dir.join("yarn_spinner.proto");
+    let file_string = proto_file.to_str().unwrap();
+    println!("cargo:rerun-if-changed={file_string}");
     prost_build::compile_protos(&[proto_file], &[include_dir])?;
     Ok(())
 }

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 pub use read_only_dialogue::*;
 use std::fmt::Debug;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock};
 use yarn_slinger_core::prelude::*;
 
@@ -13,7 +13,7 @@ mod read_only_dialogue;
 pub struct Dialogue {
     /// The object that provides access to storing and retrieving the values of variables.
     pub variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
-    pub dialogue_data: ReadOnlyDialogue,
+    dialogue_data: ReadOnlyDialogue,
 
     /// Invoked when the Dialogue needs to report debugging information.
     log_debug_message: Logger,
@@ -168,6 +168,10 @@ impl Dialogue {
         }
     }
 
+    pub fn get_readonly_access(&self) -> ReadOnlyDialogue {
+        self.dialogue_data.clone()
+    }
+
     /// Gets a value indicating whether the Dialogue is currently executing Yarn instructions.
     pub fn is_active(&self) -> bool {
         self.vm.execution_state() != ExecutionState::Stopped
@@ -304,25 +308,29 @@ impl Dialogue {
         self
     }
 
-    pub fn analyse(&mut self) -> ! {
-        // ## Implementation notes
-        // It would be more ergonomic to not expose this and call it automatically.
-        // We should probs remove this from the API.
-        // Call it when running the first `continue_` after adding a program or something.
-        todo!()
-    }
-
-    pub fn parse_markup(&self, _line: &str) -> ! {
-        // ## Implementation notes
-        // It would be more ergonomic to not expose this and call it automatically.
-        // We should probs remove this from the API.
-        // Pass the MarkupResult directly into the LineHandler
-        todo!()
-    }
-
     /// Unloads all nodes from the Dialogue.
     pub fn unload_all(&mut self) {
         self.vm.unload_programs()
+    }
+}
+
+impl AsRef<ReadOnlyDialogue> for Dialogue {
+    fn as_ref(&self) -> &ReadOnlyDialogue {
+        &self.dialogue_data
+    }
+}
+
+impl Deref for Dialogue {
+    type Target = ReadOnlyDialogue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.dialogue_data
+    }
+}
+
+impl DerefMut for Dialogue {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.dialogue_data
     }
 }
 

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -8,6 +8,16 @@ use yarn_slinger_core::prelude::*;
 mod read_only_dialogue;
 
 /// Co-ordinates the execution of Yarn programs.
+///
+/// ## Implementation notes
+///
+/// The original implementation allows calling [`Dialogue`] from handlers freely.
+/// Rust's ownership rules rightfully prevent us from doing that, so the methods that
+/// are useful to call from handlers are exposed in [`ReadOnlyDialogue`].
+///
+/// It implements [`Send`] and [`Sync`], so it can be freely moved into handlers after being retrieved via [`Dialogue::get_read_only`].
+/// [`Dialogue`] also implements [`Deref`] for [`ReadOnlyDialogue`], so you don't need to worry about this distinction if
+/// you're only calling the [`Dialogue`] from outside handlers.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct Dialogue {

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -168,7 +168,8 @@ impl Dialogue {
         }
     }
 
-    pub fn get_readonly_access(&self) -> ReadOnlyDialogue {
+    /// Retrieves a read-only view of the [`Dialogue`] that is safe to be passed to handlers.
+    pub fn get_read_only(&self) -> ReadOnlyDialogue {
         self.dialogue_data.clone()
     }
 
@@ -218,14 +219,6 @@ impl Dialogue {
             }
         }
         self
-    }
-
-    /// Gets the name of the node that this Dialogue is currently executing.
-    ///
-    /// If [`Dialogue::continue_`] has never been called, this value
-    /// will be [`None`].
-    pub fn current_node(&self) -> Option<&str> {
-        self.vm.current_node_name()
     }
 
     /// Prepares the [`Dialogue`] that the user intends to start running a node.

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -181,8 +181,16 @@ impl Dialogue {
     }
 
     /// The object that provides access to storing and retrieving the values of variables.
-    pub fn variable_storage(&self) -> Arc<RwLock<dyn VariableStorage + 'static + Send + Sync>> {
-        self.variable_storage.clone()
+    pub fn variable_storage(
+        &self,
+    ) -> impl Deref<Target = dyn VariableStorage + 'static + Send + Sync> + '_ {
+        self.variable_storage.read().unwrap()
+    }
+
+    pub fn variable_storage_mut(
+        &mut self,
+    ) -> impl DerefMut<Target = dyn VariableStorage + 'static + Send + Sync> + '_ {
+        self.variable_storage.write().unwrap()
     }
 
     /// See [`Dialogue::library`].

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -69,7 +69,8 @@ impl Dialogue {
         &mut self,
         logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
     ) -> &mut Self {
-        self.vm.log_debug_message = Box::new(logger);
+        self.handler_safe_dialogue.log_debug_message = Box::new(logger.clone());
+        self.vm.set_log_debug_message(logger);
         self
     }
 
@@ -77,7 +78,8 @@ impl Dialogue {
         &mut self,
         logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
     ) -> &mut Self {
-        self.vm.log_error_message = Box::new(logger);
+        self.handler_safe_dialogue.log_error_message = Box::new(logger.clone());
+        self.vm.set_log_error_message(logger);
         self
     }
 

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -1,11 +1,12 @@
 use crate::prelude::*;
-pub use read_only_dialogue::*;
+pub use handler_safe_dialogue::*;
+pub(crate) use shared_state::*;
 use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, RwLock};
+use std::ops::Deref;
 use yarn_slinger_core::prelude::*;
 
-mod read_only_dialogue;
+mod handler_safe_dialogue;
+mod shared_state;
 
 /// Co-ordinates the execution of Yarn programs.
 ///
@@ -18,89 +19,73 @@ mod read_only_dialogue;
 /// It implements [`Send`] and [`Sync`], so it can be freely moved into handlers after being retrieved via [`Dialogue::get_read_only`].
 /// [`Dialogue`] also implements [`Deref`] for [`ReadOnlyDialogue`], so you don't need to worry about this distinction if
 /// you're only calling the [`Dialogue`] from outside handlers.
-#[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Dialogue {
-    /// The object that provides access to storing and retrieving the values of variables.
-    variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
-
-    read_only_dialogue: ReadOnlyDialogue,
-
-    /// Invoked when the Dialogue needs to report debugging information.
-    log_debug_message: Logger,
-
-    /// Invoked when the Dialogue needs to report an error.
-    log_error_message: Logger,
-
     vm: VirtualMachine,
+    shared_state: SharedState,
+    handler_safe_dialogue: HandlerSafeDialogue,
 }
 
 impl Default for Dialogue {
     fn default() -> Self {
-        let variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>> =
-            Arc::new(RwLock::new(MemoryVariableStore::default()));
+        let shared_state = SharedState::default();
+        let handler_safe_dialogue = HandlerSafeDialogue::from_shared_state(shared_state.clone());
 
-        let mut vm = VirtualMachine::with_variable_storage(variable_storage.clone());
-        let storage_one = variable_storage.clone();
-        let storage_two = variable_storage.clone();
+        let mut vm = VirtualMachine::with_shared_state(shared_state.clone());
+        let storage_one = shared_state.variable_storage_shared();
+        let storage_two = storage_one.clone();
         vm.library
             .register_function("visited", move |node: String| -> bool {
-                is_node_visited(storage_one.read().unwrap().deref(), &node)
+                is_node_visited(storage_one.read().unwrap().deref().as_ref(), &node)
             })
             .register_function("visited_count", move |node: String| -> f32 {
-                get_node_visit_count(storage_two.read().unwrap().deref(), &node)
+                get_node_visit_count(storage_two.read().unwrap().deref().as_ref(), &node)
             });
-        let dialogue_data = vm.read_only_dialogue.clone();
         Self {
-            variable_storage,
-            log_debug_message: vm.log_debug_message.clone(),
-            log_error_message: vm.log_error_message.clone(),
             vm,
-            read_only_dialogue: dialogue_data,
+            shared_state,
+            handler_safe_dialogue,
         }
     }
 }
 
+impl SharedStateHolder for Dialogue {
+    fn shared_state(&self) -> &SharedState {
+        &self.shared_state
+    }
+}
+
+// Builder API
 impl Dialogue {
-    pub const DEFAULT_START_NODE_NAME: &'static str = "Start";
-
-    pub fn with_variable_storage(
-        mut self,
+    pub fn set_variable_storage<T: VariableStorage + 'static + Send + Sync>(
+        &mut self,
         variable_storage: impl VariableStorage + 'static + Send + Sync,
-    ) -> Self {
-        self.variable_storage = Arc::new(RwLock::new(variable_storage));
-        self.vm.variable_storage = self.variable_storage.clone();
+    ) -> &mut Self {
+        *self.variable_storage_mut() = Box::new(variable_storage);
         self
     }
 
-    pub fn with_library(mut self, library: Library) -> Self {
-        self.vm.library = library;
+    pub fn set_log_debug_message(
+        &mut self,
+        logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.log_debug_message = Box::new(logger);
         self
     }
 
-    pub fn with_log_debug_message(
-        mut self,
-        logger: impl Fn(String) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.log_debug_message = logger.into();
-        self.vm.log_debug_message = self.log_debug_message.clone();
+    pub fn set_log_error_message(
+        &mut self,
+        logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.log_error_message = Box::new(logger);
         self
     }
 
-    pub fn with_log_error_message(
-        mut self,
-        logger: impl Fn(String) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.log_error_message = logger.into();
-        self.vm.log_error_message = self.log_error_message.clone();
-        self
-    }
-
-    pub fn with_line_handler(
-        mut self,
-        line_handler: impl Fn(Line) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.line_handler = line_handler.into();
+    pub fn set_line_handler(
+        &mut self,
+        line_handler: impl Fn(Line, &mut HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.line_handler = Box::new(line_handler);
         self
     }
 
@@ -110,76 +95,84 @@ impl Dialogue {
     /// Before [`Dialogue::continue_`] can be called to resume execution,
     /// [`Dialogue::set_selected_option`] must be called to indicate which
     /// [`DialogueOption`] was selected by the user. If [`Dialogue::set_selected_option`] is not called, a panic occurs.
-    pub fn with_options_handler(
-        mut self,
-        options_handler: impl Fn(Vec<DialogueOption>) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.options_handler = options_handler.into();
+    pub fn set_options_handler(
+        &mut self,
+        options_handler: impl FnMut(Vec<DialogueOption>, &mut HandlerSafeDialogue)
+            + Clone
+            + 'static
+            + Send
+            + Sync,
+    ) -> &mut Self {
+        self.vm.options_handler = Box::new(options_handler);
         self
     }
 
     /// The [`CommandHandler`] that is called when a command is to be delivered to the game.
-    pub fn with_command_handler(
-        mut self,
-        command_handler: impl Fn(Command) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.command_handler = command_handler.into();
+    pub fn set_command_handler(
+        &mut self,
+        command_handler: impl FnMut(Command, &mut HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.command_handler = Box::new(command_handler);
         self
     }
 
     /// The [`NodeCompleteHandler`] that is called when a node is complete.
-    pub fn with_node_complete_handler(
-        mut self,
-        node_complete_handler: impl Fn(String) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.node_complete_handler = node_complete_handler.into();
+    pub fn set_node_complete_handler(
+        &mut self,
+        node_complete_handler: impl FnMut(String, &mut HandlerSafeDialogue)
+            + Clone
+            + 'static
+            + Send
+            + Sync,
+    ) -> &mut Self {
+        self.vm.node_complete_handler = Box::new(node_complete_handler);
         self
     }
 
     /// The [`NodeStartHandler`] that is called when a node is started.
-    pub fn with_node_start_handler(
-        mut self,
-        node_start_handler: impl Fn(String) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.node_start_handler = Some(node_start_handler.into());
+    pub fn set_node_start_handler(
+        &mut self,
+        node_start_handler: impl FnMut(String, &mut HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.node_start_handler = Some(Box::new(node_start_handler));
         self
     }
 
     /// The [`DialogueCompleteHandler`] that is called when the Dialogue reaches its end.
-    pub fn with_dialogue_complete_handler(
-        mut self,
-        dialogue_complete_handler: impl Fn() + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.dialogue_complete_handler = Some(dialogue_complete_handler.into());
+    pub fn set_dialogue_complete_handler(
+        &mut self,
+        dialogue_complete_handler: impl FnMut(&mut HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.vm.dialogue_complete_handler = Some(Box::new(dialogue_complete_handler));
         self
     }
 
     /// The [`PrepareForLinesHandler`] that is called when the dialogue anticipates delivering some lines.
-    pub fn with_prepare_for_lines_handler(
-        mut self,
-        prepare_for_lines_handler: impl Fn(Vec<LineId>) + Clone + 'static + Send + Sync,
-    ) -> Self {
-        self.vm.prepare_for_lines_handler = Some(prepare_for_lines_handler.into());
+    pub fn set_prepare_for_lines_handler(
+        &mut self,
+        prepare_for_lines_handler: impl Fn(Vec<LineId>, &mut HandlerSafeDialogue)
+            + Clone
+            + 'static
+            + Send
+            + Sync,
+    ) -> &mut Self {
+        self.vm.prepare_for_lines_handler = Some(Box::new(prepare_for_lines_handler));
         self
     }
 
-    pub fn with_language_code(self, language_code: impl Into<String>) -> Self {
-        self.read_only_dialogue
-            .language_code
-            .write()
-            .unwrap()
-            .replace(language_code.into());
+    pub fn set_language_code(&mut self, language_code: impl Into<String>) -> &mut Self {
+        self.language_code_mut().replace(language_code.into());
         self
     }
+}
 
-    /// Retrieves a read-only view of the [`Dialogue`] that is safe to be passed to handlers.
-    pub fn get_read_only(&self) -> ReadOnlyDialogue {
-        self.read_only_dialogue.clone()
-    }
+// VM proxy
+impl Dialogue {
+    pub const DEFAULT_START_NODE_NAME: &'static str = "Start";
 
     /// Gets a value indicating whether the Dialogue is currently executing Yarn instructions.
     pub fn is_active(&self) -> bool {
-        self.vm.execution_state() != ExecutionState::Stopped
+        *self.execution_state() != ExecutionState::Stopped
     }
 
     /// Gets the [`Library`] that this Dialogue uses to locate functions.
@@ -190,48 +183,32 @@ impl Dialogue {
         &self.vm.library
     }
 
-    /// The object that provides access to storing and retrieving the values of variables.
-    pub fn variable_storage(
-        &self,
-    ) -> impl Deref<Target = dyn VariableStorage + 'static + Send + Sync> + '_ {
-        self.variable_storage.read().unwrap()
-    }
-
-    pub fn variable_storage_mut(
-        &mut self,
-    ) -> impl DerefMut<Target = dyn VariableStorage + 'static + Send + Sync> + '_ {
-        self.variable_storage.write().unwrap()
-    }
-
     /// See [`Dialogue::library`].
     pub fn library_mut(&mut self) -> &mut Library {
         &mut self.vm.library
     }
 
-    pub fn with_new_program(mut self, program: Program) -> Self {
-        self.set_program(program);
-        self
+    /// The object that provides access to storing and retrieving the values of variables.
+    /// Be aware that accessing this object will block [`Dialogue::continue_`] and vice versa, so try to not cause a deadlock.
+    pub fn variable_storage(&self) -> SharedMemoryVariableStore {
+        SharedMemoryVariableStore(self.variable_storage_shared())
     }
 
-    pub fn with_additional_program(mut self, program: Program) -> Self {
-        self.add_program(program);
-        self
-    }
-
-    pub fn set_program(&mut self, program: Program) -> &mut Self {
-        *self.read_only_dialogue.program.write().unwrap() = Some(program);
+    pub fn replace_program(&mut self, program: Program) -> &mut Self {
+        self.vm.program_mut().replace(program);
         self.vm.reset_state();
         self
     }
 
     pub fn add_program(&mut self, program: Program) -> &mut Self {
         {
-            let mut existing_program = self.read_only_dialogue.program.write().unwrap();
+            let mut existing_program = self.program_mut();
             if let Some(existing_program) = existing_program.as_mut() {
                 *existing_program =
                     Program::combine(vec![existing_program.clone(), program]).unwrap();
             } else {
                 *existing_program = Some(program);
+                drop(existing_program);
                 self.vm.reset_state();
             }
         }
@@ -253,28 +230,8 @@ impl Dialogue {
         self
     }
 
-    pub fn set_start_node(&mut self) -> &mut Self {
+    pub fn set_node_to_start(&mut self) -> &mut Self {
         self.set_node(Self::DEFAULT_START_NODE_NAME);
-        self
-    }
-
-    /// Signals to the [`Dialogue`] that the user has selected a specified [`DialogueOption`].
-    ///
-    /// After the Dialogue delivers an [`OptionSet`], this method must be called before [`Dialogue::continue_`] is called.
-    ///
-    /// The ID number that should be passed as the parameter to this method should be the [`DialogueOption::Id`]
-    /// field in the [`DialogueOption`] that represents the user's selection.
-    ///
-    /// ## Panics
-    /// - If the Dialogue is not expecting an option to be selected.
-    /// - If the option ID is not found in the current [`OptionSet`].
-    ///
-    /// ## See Also
-    /// - [`Dialogue::continue_`]
-    /// - [`OptionsHandler`]
-    /// - [`OptionSet`]
-    pub fn set_selected_option(&mut self, selected_option_id: OptionId) -> &mut Self {
-        self.vm.set_selected_option(selected_option_id);
         self
     }
 
@@ -303,7 +260,7 @@ impl Dialogue {
     /// For this reason, we disallow mutating the [`Dialogue`] within any handler.
     pub fn continue_(&mut self) -> &mut Self {
         // Cannot 'continue' an already running VM.
-        if self.vm.execution_state() != ExecutionState::Running {
+        if *self.execution_state() != ExecutionState::Running {
             self.vm.continue_();
         }
         self
@@ -324,23 +281,56 @@ impl Dialogue {
     }
 }
 
-impl AsRef<ReadOnlyDialogue> for Dialogue {
-    fn as_ref(&self) -> &ReadOnlyDialogue {
-        &self.read_only_dialogue
+// HandlerSafeDialogue proxy
+impl Dialogue {
+    pub fn node_names(&self) -> Option<Vec<String>> {
+        self.handler_safe_dialogue.node_names()
+    }
+    pub fn get_string_id_for_node(&self, node_name: &str) -> Option<String> {
+        self.handler_safe_dialogue.get_string_id_for_node(node_name)
+    }
+    pub fn get_tags_for_node(&self, node_name: &str) -> Option<Vec<String>> {
+        self.handler_safe_dialogue.get_tags_for_node(node_name)
+    }
+    pub fn node_exists(&self, node_name: &str) -> bool {
+        self.handler_safe_dialogue.node_exists(node_name)
+    }
+
+    pub fn expand_substitutions<'a>(
+        text: &str,
+        substitutions: impl IntoIterator<Item = &'a str>,
+    ) -> String {
+        HandlerSafeDialogue::expand_substitutions(text, substitutions)
+    }
+    pub fn current_node(&self) -> Option<String> {
+        self.handler_safe_dialogue.current_node()
+    }
+    pub fn language_code(&self) -> Option<String> {
+        self.handler_safe_dialogue.language_code()
+    }
+    pub fn analyse(&self) -> ! {
+        self.handler_safe_dialogue.analyse()
+    }
+    pub fn parse_markup(&self, line: &str) -> String {
+        self.handler_safe_dialogue.parse_markup(line)
+    }
+
+    pub fn set_selected_option(&mut self, selected_option_id: OptionId) -> &mut Self {
+        self.handler_safe_dialogue
+            .set_selected_option(selected_option_id);
+        self
     }
 }
 
-impl Deref for Dialogue {
-    type Target = ReadOnlyDialogue;
-
-    fn deref(&self) -> &Self::Target {
-        &self.read_only_dialogue
+impl AsRef<HandlerSafeDialogue> for Dialogue {
+    fn as_ref(&self) -> &HandlerSafeDialogue {
+        &self.handler_safe_dialogue
     }
 }
 
-impl DerefMut for Dialogue {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.read_only_dialogue
+impl AsMut<HandlerSafeDialogue> for Dialogue {
+    fn as_mut(&mut self) -> &mut HandlerSafeDialogue {
+        &mut self.handler_safe_dialogue
     }
 }
 
@@ -367,8 +357,8 @@ mod tests {
     #[test]
     fn can_set_handler() {
         let _dialogue = Dialogue::default()
-            .with_log_debug_message(|_| {})
-            .with_options_handler(|_| {});
+            .set_log_debug_message(|_, _| {})
+            .set_options_handler(|_, _| {});
     }
 
     #[test]

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -343,7 +343,7 @@ impl Dialogue {
         }
     }
 
-    pub fn analyse(&mut self) {
+    pub fn analyse(&mut self) -> ! {
         // ## Implementation notes
         // It would be more ergonomic to not expose this and call it automatically.
         // We should probs remove this from the API.
@@ -351,12 +351,32 @@ impl Dialogue {
         todo!()
     }
 
-    pub fn parse_markup(&mut self) {
+    pub fn parse_markup(&self, _line: &str) -> ! {
         // ## Implementation notes
         // It would be more ergonomic to not expose this and call it automatically.
         // We should probs remove this from the API.
         // Pass the MarkupResult directly into the LineHandler
         todo!()
+    }
+
+    /// Replaces all substitution markers in a text with the given
+    /// substitution list.
+    ///
+    /// This method replaces substitution markers - for example, `{0}`
+    /// - with the corresponding entry in `substitutions`.
+    /// If `test` contains a substitution marker whose
+    /// index is not present in `substitutions`, it is
+    /// ignored.
+    pub fn expand_substitutions<'a>(
+        text: &str,
+        substitutions: impl IntoIterator<Item = &'a str>,
+    ) -> String {
+        substitutions
+            .into_iter()
+            .enumerate()
+            .fold(text.to_owned(), |text, (i, substitution)| {
+                text.replace(&format!("{{{i}}}",), substitution)
+            })
     }
 
     fn get_node_logging_errors(&self, node_name: &str) -> Option<&Node> {

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -57,6 +57,10 @@ impl SharedStateHolder for Dialogue {
 
 // Builder API
 impl Dialogue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn set_variable_storage<T: VariableStorage + 'static + Send + Sync>(
         &mut self,
         variable_storage: impl VariableStorage + 'static + Send + Sync,

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -59,7 +59,6 @@ impl Default for Dialogue {
 impl Dialogue {
     pub const DEFAULT_START_NODE_NAME: &'static str = "Start";
 
-    /// Initializes a new instance of the [`Dialogue`] class.
     pub fn with_variable_storage(
         mut self,
         variable_storage: impl VariableStorage + 'static + Send + Sync,

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -1,9 +1,11 @@
 use crate::prelude::*;
-use log::*;
+pub use read_only_dialogue::*;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 use yarn_slinger_core::prelude::*;
+
+mod read_only_dialogue;
 
 /// Co-ordinates the execution of Yarn programs.
 #[non_exhaustive]
@@ -11,6 +13,7 @@ use yarn_slinger_core::prelude::*;
 pub struct Dialogue {
     /// The object that provides access to storing and retrieving the values of variables.
     pub variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
+    pub dialogue_data: Arc<RwLock<ReadOnlyDialogue>>,
 
     /// Invoked when the Dialogue needs to report debugging information.
     log_debug_message: Logger,
@@ -45,13 +48,14 @@ impl Default for Dialogue {
             .register_function("visited_count", move |node: String| -> f32 {
                 get_node_visit_count(storage_two.read().unwrap().deref(), &node)
             });
-
+        let dialogue_data = vm.dialogue_data.clone();
         Self {
             variable_storage,
-            log_debug_message: Logger(Box::new(|msg| debug!("{msg}"))),
-            log_error_message: Logger(Box::new(|msg| error!("{msg}"))),
+            log_debug_message: vm.log_debug_message.clone(),
+            log_error_message: vm.log_error_message.clone(),
             language_code: Default::default(),
             vm,
+            dialogue_data,
         }
     }
 }
@@ -193,18 +197,29 @@ impl Dialogue {
     }
 
     pub fn set_program(&mut self, program: Program) -> &mut Self {
-        self.vm.program = Some(program);
+        self.dialogue_data.write().unwrap().program = Some(program);
         self.vm.reset_state();
         self
     }
 
     pub fn add_program(&mut self, program: Program) -> &mut Self {
-        if let Some(existing_program) = self.program_mut() {
+        let mut dialogue_data = self.dialogue_data.write().unwrap();
+        if let Some(existing_program) = &mut dialogue_data.program {
             *existing_program = Program::combine(vec![existing_program.clone(), program]).unwrap();
+            drop(dialogue_data);
         } else {
+            drop(dialogue_data);
             self.set_program(program);
         }
         self
+    }
+
+    /// Gets the name of the node that this Dialogue is currently executing.
+    ///
+    /// If [`Dialogue::continue_`] has never been called, this value
+    /// will be [`None`].
+    pub fn current_node(&self) -> Option<&str> {
+        self.vm.current_node_name()
     }
 
     /// Prepares the [`Dialogue`] that the user intends to start running a node.
@@ -287,61 +302,6 @@ impl Dialogue {
         self
     }
 
-    /// Gets the names of the nodes in the currently loaded Program, if there is one.
-    pub fn node_names(&self) -> Option<impl Iterator<Item = &str>> {
-        self.vm
-            .program
-            .as_ref()
-            .map(|program| program.nodes.keys().map(|s| s.as_str()))
-    }
-
-    /// Gets the name of the node that this Dialogue is currently executing.
-    ///
-    /// If [`Dialogue::continue_`] has never been called, this value
-    /// will be [`None`].
-    pub fn current_node(&self) -> Option<&str> {
-        self.vm.current_node_name()
-    }
-
-    /// Returns the string ID that contains the original, uncompiled source
-    /// text for a node.
-    ///
-    /// A node's source text will only be present in the string table if its
-    /// `tags` header contains `rawText`.
-    ///
-    /// Because the [`Dialogue`] API is designed to be unaware
-    /// of the contents of the string table, this method does not test to
-    /// see if the string table contains an entry with the line ID. You will
-    /// need to test for that yourself.
-    pub fn get_string_id_for_node(&self, node_name: &str) -> Option<String> {
-        self.get_node_logging_errors(node_name)
-            .map(|_| format!("line:{node_name}"))
-    }
-
-    /// Returns the tags for the node `node_name`.
-    ///
-    /// The tags for a node are defined by setting the `tags` header in
-    /// the node's source code. This header must be a space-separated list
-    ///
-    /// Returns [`None`] if the node is not present in the program.
-    pub fn get_tags_for_node(&self, node_name: &str) -> Option<impl Iterator<Item = &str>> {
-        self.get_node_logging_errors(node_name)
-            .map(|node| node.tags.iter().map(|s| s.as_str()))
-    }
-
-    /// Gets a value indicating whether a specified node exists in the
-    /// Program.
-    pub fn node_exists(&self, node_name: &str) -> bool {
-        // Not calling `get_node_logging_errors` because this method does not write errors when there are no nodes.
-        if let Some(program) = self.program() {
-            program.nodes.contains_key(node_name)
-        } else {
-            self.log_error_message
-                .call("Tried to call NodeExists, but no program has been loaded".to_owned());
-            false
-        }
-    }
-
     pub fn analyse(&mut self) -> ! {
         // ## Implementation notes
         // It would be more ergonomic to not expose this and call it automatically.
@@ -358,57 +318,9 @@ impl Dialogue {
         todo!()
     }
 
-    /// Replaces all substitution markers in a text with the given
-    /// substitution list.
-    ///
-    /// This method replaces substitution markers - for example, `{0}`
-    /// - with the corresponding entry in `substitutions`.
-    /// If `test` contains a substitution marker whose
-    /// index is not present in `substitutions`, it is
-    /// ignored.
-    pub fn expand_substitutions<'a>(
-        text: &str,
-        substitutions: impl IntoIterator<Item = &'a str>,
-    ) -> String {
-        substitutions
-            .into_iter()
-            .enumerate()
-            .fold(text.to_owned(), |text, (i, substitution)| {
-                text.replace(&format!("{{{i}}}",), substitution)
-            })
-    }
-
-    fn get_node_logging_errors(&self, node_name: &str) -> Option<&Node> {
-        if let Some(program) = self.program() {
-            if program.nodes.is_empty() {
-                self.log_error_message
-                    .call("No nodes are loaded".to_owned());
-                None
-            } else if let Some(node) = program.nodes.get(node_name) {
-                Some(node)
-            } else {
-                self.log_error_message
-                    .call(format!("No node named {node_name}"));
-                None
-            }
-        } else {
-            self.log_error_message
-                .call("No program is loaded".to_owned());
-            None
-        }
-    }
-
     /// Unloads all nodes from the Dialogue.
     pub fn unload_all(&mut self) {
         self.vm.unload_programs()
-    }
-
-    fn program(&self) -> Option<&Program> {
-        self.vm.program.as_ref()
-    }
-
-    fn program_mut(&mut self) -> Option<&mut Program> {
-        self.vm.program.as_mut()
     }
 }
 

--- a/crates/runtime/src/dialogue/handler_safe_dialogue.rs
+++ b/crates/runtime/src/dialogue/handler_safe_dialogue.rs
@@ -76,8 +76,7 @@ impl HandlerSafeDialogue {
             .map(|node| node.tags)
     }
 
-    /// Gets a value indicating whether a specified node exists in the
-    /// Program.
+    /// Gets a value indicating whether a specified node exists in the Program.
     pub fn node_exists(&self, node_name: &str) -> bool {
         // Not calling `get_node_logging_errors` because this method does not write errors when there are no nodes.
         if let Some(program) = self.program().as_ref() {
@@ -178,7 +177,6 @@ impl HandlerSafeDialogue {
     /// - [`Dialogue::continue_`]
     /// - [`OptionsHandler`]
     /// - [`OptionSet`]
-
     pub fn set_selected_option(&mut self, selected_option_id: OptionId) {
         assert_eq!(ExecutionState::WaitingOnOptionSelection, *self.execution_state(), "SetSelectedOption was called, but Dialogue wasn't waiting for a selection. \
                 This method should only be called after the Dialogue is waiting for the user to select an option.");
@@ -202,5 +200,10 @@ impl HandlerSafeDialogue {
 
         // We're no longer in the WaitingForOptions state; we are now waiting for our game to let us continue
         *self.execution_state_mut() = ExecutionState::WaitingForContinue;
+    }
+
+    /// Gets a value indicating whether the Dialogue is currently executing Yarn instructions.
+    pub fn is_active(&self) -> bool {
+        *self.execution_state() != ExecutionState::Stopped
     }
 }

--- a/crates/runtime/src/dialogue/handler_safe_dialogue.rs
+++ b/crates/runtime/src/dialogue/handler_safe_dialogue.rs
@@ -1,43 +1,51 @@
 use crate::prelude::*;
 use log::{debug, error};
-use std::sync::{Arc, RwLock};
+use std::ops::Deref;
 use yarn_slinger_core::prelude::*;
 
-/// A read-only view of a [`Dialogue`]. Represents the methods that are okay to be called from handlers.
-/// Since this type is `Send + Sync`, you can get a copy with [`Dialogue::get_read_only`] and `move` it into a handler.
+/// A view of a [`Dialogue`]. Represents the subset of methods that are okay to be called from handlers.
+/// Since this type is `Send + Sync`, you can get a copy with [`Dialogue::get_handler_safe_dialogue`] and `move` it into a handler.
 ///
 /// ## Implementation notes
 ///
 /// This type is not present in the original. We need to use it to cleanly borrow data from handlers.
 /// The original just calls [`Dialogue`] for both mutable and immutable access anywhere,
 /// which is of course a big no-no in Rust.
-#[derive(Debug, Clone)]
-pub struct ReadOnlyDialogue {
-    pub(crate) program: Arc<RwLock<Option<Program>>>,
-    pub(crate) current_node_name: Arc<RwLock<Option<String>>>,
+#[derive(Debug)]
+pub struct HandlerSafeDialogue {
     pub(crate) log_debug_message: Logger,
     pub(crate) log_error_message: Logger,
-    pub(crate) language_code: Arc<RwLock<Option<String>>>,
+    shared_state: SharedState,
 }
 
-impl Default for ReadOnlyDialogue {
-    fn default() -> Self {
-        ReadOnlyDialogue {
-            program: Arc::new(RwLock::new(None)),
-            current_node_name: Arc::new(RwLock::new(None)),
-            log_debug_message: Logger(Box::new(|msg: String| debug!("{}", msg))),
-            log_error_message: Logger(Box::new(|msg: String| error!("{}", msg))),
-            language_code: Arc::new(RwLock::new(None)),
-        }
+impl SharedStateHolder for HandlerSafeDialogue {
+    fn shared_state(&self) -> &SharedState {
+        &self.shared_state
     }
 }
 
-impl ReadOnlyDialogue {
+impl HandlerSafeDialogue {
+    pub(crate) fn from_shared_state(shared_state: SharedState) -> Self {
+        // Can't use a closure because the Rust type inference gets a bit confused :<
+        fn default_logger(msg: String, _dialogue: &HandlerSafeDialogue) {
+            debug!("{}", msg)
+        }
+
+        fn default_error(msg: String, _dialogue: &HandlerSafeDialogue) {
+            error!("{}", msg)
+        }
+
+        HandlerSafeDialogue {
+            log_debug_message: Box::new(default_logger),
+            log_error_message: Box::new(default_error),
+            shared_state,
+        }
+    }
+
     /// Gets the names of the nodes in the currently loaded Program, if there is one.
     pub fn node_names(&self) -> Option<Vec<String>> {
-        self.program
-            .read()
-            .unwrap()
+        self.program()
+            .deref()
             .as_ref()
             .map(|program| program.nodes.keys().cloned().collect())
     }
@@ -72,11 +80,13 @@ impl ReadOnlyDialogue {
     /// Program.
     pub fn node_exists(&self, node_name: &str) -> bool {
         // Not calling `get_node_logging_errors` because this method does not write errors when there are no nodes.
-        if let Some(program) = self.program.read().unwrap().as_ref() {
+        if let Some(program) = self.program().as_ref() {
             program.nodes.contains_key(node_name)
         } else {
-            self.log_error_message
-                .call("Tried to call NodeExists, but no program has been loaded".to_owned());
+            self.log_error_message.call(
+                "Tried to call NodeExists, but no program has been loaded".to_owned(),
+                self,
+            );
             false
         }
     }
@@ -106,7 +116,7 @@ impl ReadOnlyDialogue {
     /// If [`Dialogue::continue_`] has never been called, this value
     /// will be [`None`].
     pub fn current_node(&self) -> Option<String> {
-        self.current_node_name.read().unwrap().clone()
+        self.current_node_name().clone()
     }
 
     /// The [`Dialogue`]'s locale, as an IETF BCP 47 code.
@@ -117,7 +127,7 @@ impl ReadOnlyDialogue {
     /// For example, the code "en-US" represents the English language as
     /// used in the United States.
     pub fn language_code(&self) -> Option<String> {
-        self.language_code.read().unwrap().clone()
+        SharedStateHolder::language_code(self).clone()
     }
 
     pub fn analyse(&self) -> ! {
@@ -134,22 +144,63 @@ impl ReadOnlyDialogue {
     }
 
     fn get_node_logging_errors(&self, node_name: &str) -> Option<Node> {
-        if let Some(program) = self.program.read().unwrap().as_ref() {
+        if let Some(program) = self.program().as_ref() {
             if program.nodes.is_empty() {
                 self.log_error_message
-                    .call("No nodes are loaded".to_owned());
+                    .call("No nodes are loaded".to_owned(), self);
                 None
             } else if let Some(node) = program.nodes.get(node_name) {
                 Some(node.clone())
             } else {
                 self.log_error_message
-                    .call(format!("No node named {node_name}"));
+                    .call(format!("No node named {node_name}"), self);
                 None
             }
         } else {
             self.log_error_message
-                .call("No program is loaded".to_owned());
+                .call("No program is loaded".to_owned(), self);
             None
         }
+    }
+
+    /// Signals to the [`Dialogue`] that the user has selected a specified [`DialogueOption`].
+    ///
+    /// After the Dialogue delivers an [`OptionSet`], this method must be called before [`Dialogue::continue_`] is called.
+    ///
+    /// The ID number that should be passed as the parameter to this method should be the [`DialogueOption::Id`]
+    /// field in the [`DialogueOption`] that represents the user's selection.
+    ///
+    /// ## Panics
+    /// - If the Dialogue is not expecting an option to be selected.
+    /// - If the option ID is not found in the current [`OptionSet`].
+    ///
+    /// ## See Also
+    /// - [`Dialogue::continue_`]
+    /// - [`OptionsHandler`]
+    /// - [`OptionSet`]
+
+    pub fn set_selected_option(&mut self, selected_option_id: OptionId) {
+        assert_eq!(ExecutionState::WaitingOnOptionSelection, *self.execution_state(), "SetSelectedOption was called, but Dialogue wasn't waiting for a selection. \
+                This method should only be called after the Dialogue is waiting for the user to select an option.");
+
+        assert!(
+            selected_option_id.0 < self.state().current_options.len(),
+            "{selected_option_id:?} is not a valid option ID (expected a number between 0 and {}.",
+            self.state().current_options.len() - 1
+        );
+
+        // We now know what number option was selected; push the
+        // corresponding node name to the stack.
+        let destination_node = self.state().current_options[selected_option_id.0]
+            .destination_node
+            .clone();
+        self.state_mut().push(destination_node);
+
+        // We no longer need the accumulated list of options; clear it
+        // so that it's ready for the next one
+        self.state_mut().current_options.clear();
+
+        // We're no longer in the WaitingForOptions state; we are now waiting for our game to let us continue
+        *self.execution_state_mut() = ExecutionState::WaitingForContinue;
     }
 }

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -1,0 +1,97 @@
+use crate::prelude::*;
+use yarn_slinger_core::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct ReadOnlyDialogue {
+    pub(crate) program: Option<Program>,
+    pub(crate) log_debug_message: Logger,
+    pub(crate) log_error_message: Logger,
+}
+
+impl ReadOnlyDialogue {
+    /// Gets the names of the nodes in the currently loaded Program, if there is one.
+    pub fn node_names(&self) -> Option<impl Iterator<Item = &str>> {
+        self.program
+            .as_ref()
+            .map(|program| program.nodes.keys().map(|s| s.as_str()))
+    }
+
+    /// Returns the string ID that contains the original, uncompiled source
+    /// text for a node.
+    ///
+    /// A node's source text will only be present in the string table if its
+    /// `tags` header contains `rawText`.
+    ///
+    /// Because the [`Dialogue`] API is designed to be unaware
+    /// of the contents of the string table, this method does not test to
+    /// see if the string table contains an entry with the line ID. You will
+    /// need to test for that yourself.
+    pub fn get_string_id_for_node(&self, node_name: &str) -> Option<String> {
+        self.get_node_logging_errors(node_name)
+            .map(|_| format!("line:{node_name}"))
+    }
+
+    /// Returns the tags for the node `node_name`.
+    ///
+    /// The tags for a node are defined by setting the `tags` header in
+    /// the node's source code. This header must be a space-separated list
+    ///
+    /// Returns [`None`] if the node is not present in the program.
+    pub fn get_tags_for_node(&self, node_name: &str) -> Option<impl Iterator<Item = &str>> {
+        self.get_node_logging_errors(node_name)
+            .map(|node| node.tags.iter().map(|s| s.as_str()))
+    }
+
+    /// Gets a value indicating whether a specified node exists in the
+    /// Program.
+    pub fn node_exists(&self, node_name: &str) -> bool {
+        // Not calling `get_node_logging_errors` because this method does not write errors when there are no nodes.
+        if let Some(program) = &self.program {
+            program.nodes.contains_key(node_name)
+        } else {
+            self.log_error_message
+                .call("Tried to call NodeExists, but no program has been loaded".to_owned());
+            false
+        }
+    }
+
+    /// Replaces all substitution markers in a text with the given
+    /// substitution list.
+    ///
+    /// This method replaces substitution markers - for example, `{0}`
+    /// - with the corresponding entry in `substitutions`.
+    /// If `test` contains a substitution marker whose
+    /// index is not present in `substitutions`, it is
+    /// ignored.
+    pub fn expand_substitutions<'a>(
+        text: &str,
+        substitutions: impl IntoIterator<Item = &'a str>,
+    ) -> String {
+        substitutions
+            .into_iter()
+            .enumerate()
+            .fold(text.to_owned(), |text, (i, substitution)| {
+                text.replace(&format!("{{{i}}}",), substitution)
+            })
+    }
+
+    fn get_node_logging_errors(&self, node_name: &str) -> Option<&Node> {
+        if let Some(program) = &self.program {
+            if program.nodes.is_empty() {
+                self.log_error_message
+                    .call("No nodes are loaded".to_owned());
+                None
+            } else if let Some(node) = program.nodes.get(node_name) {
+                Some(node)
+            } else {
+                self.log_error_message
+                    .call(format!("No node named {node_name}"));
+                None
+            }
+        } else {
+            self.log_error_message
+                .call("No program is loaded".to_owned());
+            None
+        }
+    }
+}

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use log::{debug, error};
 use std::sync::{Arc, RwLock};
 use yarn_slinger_core::prelude::*;
 
@@ -10,6 +11,17 @@ pub struct ReadOnlyDialogue {
     pub(crate) current_node_name: Arc<RwLock<Option<String>>>,
     pub(crate) log_debug_message: Logger,
     pub(crate) log_error_message: Logger,
+}
+
+impl Default for ReadOnlyDialogue {
+    fn default() -> Self {
+        ReadOnlyDialogue {
+            program: Arc::new(RwLock::new(None)),
+            current_node_name: Arc::new(RwLock::new(None)),
+            log_debug_message: Logger(Box::new(|msg: String| debug!("{}", msg))),
+            log_error_message: Logger(Box::new(|msg: String| error!("{}", msg))),
+        }
+    }
 }
 
 impl ReadOnlyDialogue {

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -78,6 +78,18 @@ impl ReadOnlyDialogue {
             })
     }
 
+    pub fn analyse(&self) -> ! {
+        todo!()
+    }
+
+    pub fn parse_markup(&self, _line: &str) -> ! {
+        // ## Implementation notes
+        // It would be more ergonomic to not expose this and call it automatically.
+        // We should probs remove this from the API.
+        // Pass the MarkupResult directly into the LineHandler
+        todo!()
+    }
+
     fn get_node_logging_errors(&self, node_name: &str) -> Option<Node> {
         if let Some(program) = self.program.read().unwrap().as_ref() {
             if program.nodes.is_empty() {

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -17,6 +17,7 @@ pub struct ReadOnlyDialogue {
     pub(crate) current_node_name: Arc<RwLock<Option<String>>>,
     pub(crate) log_debug_message: Logger,
     pub(crate) log_error_message: Logger,
+    pub(crate) language_code: Arc<RwLock<Option<String>>>,
 }
 
 impl Default for ReadOnlyDialogue {
@@ -26,6 +27,7 @@ impl Default for ReadOnlyDialogue {
             current_node_name: Arc::new(RwLock::new(None)),
             log_debug_message: Logger(Box::new(|msg: String| debug!("{}", msg))),
             log_error_message: Logger(Box::new(|msg: String| error!("{}", msg))),
+            language_code: Arc::new(RwLock::new(None)),
         }
     }
 }
@@ -107,16 +109,28 @@ impl ReadOnlyDialogue {
         self.current_node_name.read().unwrap().clone()
     }
 
+    /// The [`Dialogue`]'s locale, as an IETF BCP 47 code.
+    ///
+    /// This code is used to determine how the `plural` and `ordinal`
+    /// markers determine the plural class of numbers.
+    ///
+    /// For example, the code "en-US" represents the English language as
+    /// used in the United States.
+    pub fn language_code(&self) -> Option<String> {
+        self.language_code.read().unwrap().clone()
+    }
+
     pub fn analyse(&self) -> ! {
         todo!()
     }
 
-    pub fn parse_markup(&self, _line: &str) -> ! {
+    pub fn parse_markup(&self, line: &str) -> String {
         // ## Implementation notes
         // It would be more ergonomic to not expose this and call it automatically.
         // We should probs remove this from the API.
         // Pass the MarkupResult directly into the LineHandler
-        todo!()
+        // todo!()
+        line.to_owned()
     }
 
     fn get_node_logging_errors(&self, node_name: &str) -> Option<Node> {

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -2,9 +2,12 @@ use crate::prelude::*;
 use std::sync::{Arc, RwLock};
 use yarn_slinger_core::prelude::*;
 
+/// A read-only view of a [`Dialogue`]. Represents the methods that are okay to be called from handlers.
+/// Since this type is `Send + Sync`, you can get a copy with [`Dialogue::get_read_only`] and `move` it into a handler.
 #[derive(Debug, Clone)]
 pub struct ReadOnlyDialogue {
     pub(crate) program: Arc<RwLock<Option<Program>>>,
+    pub(crate) current_node_name: Arc<RwLock<Option<String>>>,
     pub(crate) log_debug_message: Logger,
     pub(crate) log_error_message: Logger,
 }
@@ -76,6 +79,14 @@ impl ReadOnlyDialogue {
             .fold(text.to_owned(), |text, (i, substitution)| {
                 text.replace(&format!("{{{i}}}",), substitution)
             })
+    }
+
+    /// Gets the name of the node that this Dialogue is currently executing.
+    ///
+    /// If [`Dialogue::continue_`] has never been called, this value
+    /// will be [`None`].
+    pub fn current_node(&self) -> Option<String> {
+        self.current_node_name.read().unwrap().clone()
     }
 
     pub fn analyse(&self) -> ! {

--- a/crates/runtime/src/dialogue/read_only_dialogue.rs
+++ b/crates/runtime/src/dialogue/read_only_dialogue.rs
@@ -5,6 +5,12 @@ use yarn_slinger_core::prelude::*;
 
 /// A read-only view of a [`Dialogue`]. Represents the methods that are okay to be called from handlers.
 /// Since this type is `Send + Sync`, you can get a copy with [`Dialogue::get_read_only`] and `move` it into a handler.
+///
+/// ## Implementation notes
+///
+/// This type is not present in the original. We need to use it to cleanly borrow data from handlers.
+/// The original just calls [`Dialogue`] for both mutable and immutable access anywhere,
+/// which is of course a big no-no in Rust.
 #[derive(Debug, Clone)]
 pub struct ReadOnlyDialogue {
     pub(crate) program: Arc<RwLock<Option<Program>>>,

--- a/crates/runtime/src/dialogue/shared_state.rs
+++ b/crates/runtime/src/dialogue/shared_state.rs
@@ -1,0 +1,98 @@
+use crate::prelude::*;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use yarn_slinger_core::prelude::*;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SharedState {
+    program: Arc<RwLock<Option<Program>>>,
+    current_node_name: Arc<RwLock<Option<String>>>,
+    language_code: Arc<RwLock<Option<String>>>,
+    variable_storage: Arc<RwLock<Box<dyn VariableStorage + Send + Sync>>>,
+    state: Arc<RwLock<State>>,
+    execution_state: Arc<RwLock<ExecutionState>>,
+    current_node: Arc<RwLock<Option<Node>>>,
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self {
+            program: Default::default(),
+            current_node_name: Default::default(),
+            language_code: Default::default(),
+            variable_storage: Arc::new(RwLock::new(Box::<MemoryVariableStore>::default())),
+            state: Default::default(),
+            execution_state: Default::default(),
+            current_node: Default::default(),
+        }
+    }
+}
+
+impl SharedStateHolder for SharedState {
+    fn shared_state(&self) -> &SharedState {
+        self
+    }
+}
+
+pub(crate) trait SharedStateHolder {
+    fn shared_state(&self) -> &SharedState;
+
+    fn program(&self) -> RwLockReadGuard<Option<Program>> {
+        self.shared_state().program.read().unwrap()
+    }
+
+    fn program_mut(&mut self) -> RwLockWriteGuard<Option<Program>> {
+        self.shared_state().program.write().unwrap()
+    }
+
+    fn current_node_name(&self) -> RwLockReadGuard<Option<String>> {
+        self.shared_state().current_node_name.read().unwrap()
+    }
+
+    fn current_node_name_mut(&mut self) -> RwLockWriteGuard<Option<String>> {
+        self.shared_state().current_node_name.write().unwrap()
+    }
+
+    fn language_code(&self) -> RwLockReadGuard<Option<String>> {
+        self.shared_state().language_code.read().unwrap()
+    }
+
+    fn language_code_mut(&mut self) -> RwLockWriteGuard<Option<String>> {
+        self.shared_state().language_code.write().unwrap()
+    }
+
+    fn variable_storage(&self) -> RwLockReadGuard<Box<dyn VariableStorage + Send + Sync>> {
+        self.shared_state().variable_storage.read().unwrap()
+    }
+
+    fn variable_storage_shared(&self) -> Arc<RwLock<Box<dyn VariableStorage + Send + Sync>>> {
+        self.shared_state().variable_storage.clone()
+    }
+
+    fn variable_storage_mut(&mut self) -> RwLockWriteGuard<Box<dyn VariableStorage + Send + Sync>> {
+        self.shared_state().variable_storage.write().unwrap()
+    }
+
+    fn state(&self) -> RwLockReadGuard<State> {
+        self.shared_state().state.read().unwrap()
+    }
+
+    fn state_mut(&mut self) -> RwLockWriteGuard<State> {
+        self.shared_state().state.write().unwrap()
+    }
+
+    fn execution_state(&self) -> RwLockReadGuard<ExecutionState> {
+        self.shared_state().execution_state.read().unwrap()
+    }
+
+    fn execution_state_mut(&mut self) -> RwLockWriteGuard<ExecutionState> {
+        self.shared_state().execution_state.write().unwrap()
+    }
+
+    fn current_node(&self) -> RwLockReadGuard<Option<Node>> {
+        self.shared_state().current_node.read().unwrap()
+    }
+
+    fn current_node_mut(&mut self) -> RwLockWriteGuard<Option<Node>> {
+        self.shared_state().current_node.write().unwrap()
+    }
+}

--- a/crates/runtime/src/dialogue_option.rs
+++ b/crates/runtime/src/dialogue_option.rs
@@ -33,3 +33,13 @@ pub struct DialogueOption {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptionId(pub(crate) usize);
+
+impl OptionId {
+    /// Constructs a new `OptionId` from the given value.
+    /// A user is supposed to use the `OptionId`s constructed by the [`Dialogue`] and not create their own.
+    ///
+    /// So, only use this method for debugging purposes.
+    pub fn construct_for_debugging(value: usize) -> Self {
+        Self(value)
+    }
+}

--- a/crates/runtime/src/handlers.rs
+++ b/crates/runtime/src/handlers.rs
@@ -104,16 +104,3 @@ impl_handler! {
     /// This method may be called any number of times during a dialogue session.
     pub struct PrepareForLinesHandler(pub PrepareForLinesHandlerFn: FnMut(Vec<LineId>));
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn can_assign_handlers() {
-        let _logger = Logger(Box::new(|message| println!("{}", message)));
-
-        let _dialogue_complete_handler =
-            DialogueCompleteHandler(Box::new(|| println!("Dialogue complete!")));
-    }
-}

--- a/crates/runtime/src/handlers/impl_handler_macro.rs
+++ b/crates/runtime/src/handlers/impl_handler_macro.rs
@@ -24,56 +24,34 @@ macro_rules! impl_handler {
 macro_rules! impl_handler_inner {
     ($(#[$attr:meta])* pub struct $struct_name:ident(pub $trait_name:ident: $fun:ident($($param:ty)?)), $($mutable:ident)?) => {
         $(#[$attr])*
-        #[derive(Debug, Clone)]
-        pub struct $struct_name(pub Box<dyn $trait_name + Send + Sync>);
+        pub type $struct_name = Box<dyn $trait_name + Send + Sync>;
 
-        impl std::ops::Deref for $struct_name {
-            type Target = Box<dyn $trait_name + Send + Sync>;
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl std::ops::DerefMut for $struct_name {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
-            }
-        }
-
-        impl<T> From<T> for $struct_name
-            where T: $fun($($param)?) + Clone + Send + Sync + 'static,
-        {
-            fn from(f: T) -> Self {
-                Self(Box::new(f))
-            }
-        }
-
-        impl Clone for Box<dyn $trait_name + Send + Sync> {
+        impl Clone for $struct_name {
             fn clone(&self) -> Self {
                 self.clone_box()
             }
         }
 
-        impl std::fmt::Debug for dyn $trait_name + Send + Sync {
+        impl std::fmt::Debug for $struct_name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, stringify!($struct_name))
             }
         }
 
         pub trait $trait_name: Send + Sync {
-            fn call(&$($mutable)? self, $(param: $param)?);
-            fn clone_box(&self) -> Box<dyn $trait_name + Send + Sync>;
+            fn call(&$($mutable)? self, $(param: $param,)? dialogue: &$($mutable)? HandlerSafeDialogue);
+            fn clone_box(&self) -> $struct_name;
         }
 
         impl<T> $trait_name for T
         where
-            T: $fun($($param)?) + Clone + Send + Sync + 'static,
+            T: $fun($($param,)? &$($mutable)? HandlerSafeDialogue) + Clone + Send + Sync + 'static,
         {
-            fn call(&$($mutable)? self, $(param: $param)?) {
-                self($(param as $param)?)
+            fn call(&$($mutable)? self, $(param: $param,)? dialogue: &$($mutable)? HandlerSafeDialogue){
+                self($(param as $param,)? dialogue)
             }
 
-            fn clone_box(&self) -> Box<dyn $trait_name + Send + Sync> {
+            fn clone_box(&self) -> $struct_name {
                 Box::new(self.clone())
             }
         }

--- a/crates/runtime/src/line.rs
+++ b/crates/runtime/src/line.rs
@@ -16,7 +16,7 @@ use crate::string_newtype;
 ///
 /// ## See also
 /// [`Dialogue::line_handler`]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Line {
     /// The ID of the line in the string table.
     pub id: LineId,

--- a/crates/runtime/src/string_newtype.rs
+++ b/crates/runtime/src/string_newtype.rs
@@ -1,7 +1,7 @@
 macro_rules! string_newtype {
     ($(#[$attr:meta])* pub struct $name:ident(pub String);) => {
         $(#[$attr])*
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub struct $name(pub String);
 
         impl std::ops::Deref for $name {

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -28,7 +28,7 @@ pub(crate) struct VirtualMachine {
     pub(crate) dialogue_complete_handler: Option<DialogueCompleteHandler>,
     pub(crate) prepare_for_lines_handler: Option<PrepareForLinesHandler>,
     pub(crate) library: Library,
-    variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
+    pub(crate) variable_storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
     state: State,
     execution_state: ExecutionState,
     current_node: Option<Node>,

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -15,8 +15,6 @@ mod state;
 
 #[derive(Debug)]
 pub(crate) struct VirtualMachine {
-    pub(crate) log_debug_message: Logger,
-    pub(crate) log_error_message: Logger,
     pub(crate) line_handler: LineHandler,
     pub(crate) options_handler: OptionsHandler,
     pub(crate) command_handler: CommandHandler,
@@ -27,6 +25,8 @@ pub(crate) struct VirtualMachine {
     pub(crate) library: Library,
     handler_safe_dialogue: HandlerSafeDialogue,
     shared: SharedState,
+    log_debug_message: Logger,
+    log_error_message: Logger,
 }
 
 impl SharedStateHolder for VirtualMachine {
@@ -218,6 +218,24 @@ impl VirtualMachine {
 
     pub(crate) fn unload_programs(&mut self) {
         *self.program_mut() = None
+    }
+
+    pub(crate) fn set_log_debug_message(
+        &mut self,
+        logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.log_debug_message = Box::new(logger);
+        self.handler_safe_dialogue.log_debug_message = self.log_debug_message.clone();
+        self
+    }
+
+    pub(crate) fn set_log_error_message(
+        &mut self,
+        logger: impl Fn(String, &HandlerSafeDialogue) + Clone + 'static + Send + Sync,
+    ) -> &mut Self {
+        self.log_error_message = Box::new(logger);
+        self.handler_safe_dialogue.log_error_message = self.log_error_message.clone();
+        self
     }
 
     /// ## Implementation note

--- a/crates/yarn_slinger/tests/error_handling_tests.rs
+++ b/crates/yarn_slinger/tests/error_handling_tests.rs
@@ -1,6 +1,7 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/ErrorHandlingTests.cs>
 
 use crate::test_base::*;
+use test_base::prelude::*;
 use yarn_slinger::prelude::*;
 
 mod test_base;

--- a/crates/yarn_slinger/tests/language_tests.rs
+++ b/crates/yarn_slinger/tests/language_tests.rs
@@ -1,7 +1,7 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/LanguageTests.cs>
 
-use crate::test_base::*;
 use std::collections::HashMap;
+use test_base::prelude::*;
 use yarn_slinger::prelude::*;
 
 mod test_base;

--- a/crates/yarn_slinger/tests/language_tests.rs
+++ b/crates/yarn_slinger/tests/language_tests.rs
@@ -159,12 +159,6 @@ fn test_number_plurals() {
 
 #[test]
 #[ignore]
-fn test_compilation_should_not_be_culture_dependent() {
-    todo!("Not ported yet")
-}
-
-#[test]
-#[ignore]
 fn test_sources() {
     todo!("Not ported yet")
 }

--- a/crates/yarn_slinger/tests/language_tests.rs
+++ b/crates/yarn_slinger/tests/language_tests.rs
@@ -12,9 +12,18 @@ use yarn_slinger::prelude::*;
 mod test_base;
 
 #[test]
-#[ignore]
 fn test_example_script() {
-    todo!("Not ported yet")
+    let path = test_data_path().join("Example.yarn");
+    let test_plan = path.with_extension("testplan");
+
+    let compilation_job = CompilationJob::default().read_file(path).unwrap();
+    let result = compile(compilation_job).unwrap_pretty();
+
+    TestBase::default()
+        .with_runtime_failure_causes_no_panic()
+        .with_compilation(result)
+        .read_test_plan(test_plan)
+        .run_standard_testcase();
 }
 
 #[test]

--- a/crates/yarn_slinger/tests/language_tests.rs
+++ b/crates/yarn_slinger/tests/language_tests.rs
@@ -1,4 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/LanguageTests.cs>
+//!
+//! ## Implementation notes
+//!
+//! Because Rust has no concept of a current global culture setting,
+//! the test `TestCompilationShouldNotBeCultureDependent` was omitted.
 
 use std::collections::HashMap;
 use test_base::prelude::*;

--- a/crates/yarn_slinger/tests/project_tests.rs
+++ b/crates/yarn_slinger/tests/project_tests.rs
@@ -5,7 +5,7 @@
 //! - AddTagsToLines: Tests functionality that, quote: "Given Yarn source code, adds line tags to the ends of all lines that need one and do not already have one."
 //!   This is only used in a certain section of the Unity project importer.
 
-use crate::test_base::*;
+use test_base::prelude::*;
 use yarn_slinger::prelude::*;
 
 mod test_base;

--- a/crates/yarn_slinger/tests/tag_tests.rs
+++ b/crates/yarn_slinger/tests/tag_tests.rs
@@ -1,6 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TagTests.cs>
 
-use crate::test_base::*;
+use test_base::prelude::*;
 use yarn_slinger::prelude::*;
 
 mod test_base;

--- a/crates/yarn_slinger/tests/test_base/extensions.rs
+++ b/crates/yarn_slinger/tests/test_base/extensions.rs
@@ -1,0 +1,37 @@
+//! Extension traits that make testing easier
+
+use crate::prelude::*;
+use yarn_slinger_compiler::prelude::*;
+
+pub trait CompileResultExt {
+    fn unwrap_pretty(self) -> Compilation;
+}
+
+impl CompileResultExt for Result<Compilation, CompilationError> {
+    fn unwrap_pretty(self) -> Compilation {
+        match self {
+            Ok(compilation) => compilation,
+            Err(error) => {
+                for diagnostic in error.diagnostics {
+                    eprintln!("{}", diagnostic);
+                }
+                panic!("Compilation failed due to Yarn errors")
+            }
+        }
+    }
+}
+
+pub trait TestCompilationJob {
+    fn from_test_source(source: &str) -> Self;
+}
+
+impl TestCompilationJob for CompilationJob {
+    fn from_test_source(source: &str) -> Self {
+        let file = File {
+            file_name: "<input>".to_string(),
+            source: create_test_node(source),
+        };
+
+        Self::default().with_file(file)
+    }
+}

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -32,7 +32,6 @@ pub mod prelude {
 
 #[derive(Debug, Clone)]
 pub struct TestBase {
-    pub storage: Arc<RwLock<dyn VariableStorage + Send + Sync>>,
     pub dialogue: Dialogue,
     test_plan: Arc<RwLock<Option<TestPlan>>>,
     string_table: Arc<RwLock<HashMap<LineId, StringInfo>>>,
@@ -159,13 +158,11 @@ impl Default for TestBase {
                 );
             })
         };
-        let storage = dialogue.variable_storage();
         Self {
             dialogue,
             test_plan,
             string_table,
             runtime_errors_cause_panic,
-            storage,
         }
     }
 }
@@ -252,13 +249,13 @@ impl TestBase {
     }
 
     pub fn storage(&self) -> impl Deref<Target = dyn VariableStorage + Send + Sync> + '_ {
-        self.storage.read().unwrap()
+        self.dialogue.variable_storage()
     }
 
     pub fn storage_mut(
         &mut self,
     ) -> impl DerefMut<Target = dyn VariableStorage + Send + Sync> + '_ {
-        self.storage.write().unwrap()
+        self.dialogue.variable_storage_mut()
     }
 }
 

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -205,7 +205,7 @@ impl TestBase {
         self
     }
 
-    pub fn with_runtime_causes_no_failures(self) -> Self {
+    pub fn runtime_failure_causes_no_panic(self) -> Self {
         self.runtime_errors_cause_panic
             .store(false, Ordering::Relaxed);
         self

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -6,6 +6,10 @@
 #![allow(dead_code)]
 
 use crate::prelude::*;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
 use yarn_slinger::prelude::*;
 
 mod extensions;
@@ -21,4 +25,58 @@ pub mod prelude {
 pub struct TestBase {
     pub dialogue: Dialogue,
     pub test_plan: TestPlan,
+    pub string_table: HashMap<LineId, StringInfo>,
+}
+
+impl TestBase {
+    /// Sets the current test plan to one loaded from a given path.
+    pub fn read_test_plan(mut self, path: &Path) -> Self {
+        self.test_plan = TestPlan::read(path);
+        self
+    }
+
+    /// Executes the named node, and checks any assertions made during
+    /// execution. Fails the test if an assertion made in Yarn fails.
+    pub fn run_standard_testcase(&mut self) {
+        self.dialogue.set_start_node();
+
+        self.dialogue.continue_();
+        while self.dialogue.is_active() {
+            self.dialogue.continue_();
+        }
+    }
+
+    /// Returns the list of .node and.yarn files in the Tests/<directory> directory.
+    pub fn file_sources(subdir: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
+        let subdir: PathBuf = PathBuf::from(subdir.as_ref());
+        let path = test_data_path().join(&subdir);
+        let allowed_extensions = ["node", "yarn"].map(|string| OsStr::new(string));
+        fs::read_dir(path)
+            .unwrap()
+            .filter_map(|entry| {
+                entry
+                    .or_else(|e| {
+                        println!("Warning: failed to read a directory entry: {e:?}");
+                        Err(e)
+                    })
+                    .ok()
+            })
+            .filter(move |entry| {
+                entry
+                    .path()
+                    .extension()
+                    .map(|ext| allowed_extensions.contains(&ext))
+                    .unwrap_or_default()
+            })
+            // don't include ".upgraded.yarn" (used in UpgraderTests)
+            .filter(|entry| entry.path().ends_with(".upgraded.yarn"))
+            .map(move |entry| subdir.join(entry.file_name()))
+    }
+
+    pub fn get_composed_text_for_line(&self, line: Line) -> String {
+        let string_info = self.string_table.get(&line.id).unwrap();
+        let substitutions = line.substitutions.iter().map(|s| s.as_str());
+        let substituted_text = Dialogue::expand_substitutions(&string_info.text, substitutions);
+        self.dialogue.parse_markup(&substituted_text)
+    }
 }

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -50,14 +50,14 @@ impl TestBase {
     pub fn file_sources(subdir: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
         let subdir: PathBuf = PathBuf::from(subdir.as_ref());
         let path = test_data_path().join(&subdir);
-        let allowed_extensions = ["node", "yarn"].map(|string| OsStr::new(string));
+        let allowed_extensions = ["node", "yarn"].map(OsStr::new);
         fs::read_dir(path)
             .unwrap()
             .filter_map(|entry| {
                 entry
-                    .or_else(|e| {
+                    .map_err(|e| {
                         println!("Warning: failed to read a directory entry: {e:?}");
-                        Err(e)
+                        e
                     })
                     .ok()
             })

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -5,83 +5,20 @@
 // are separately compiled as their own crate.
 #![allow(dead_code)]
 
-use std::path::PathBuf;
+use crate::prelude::*;
 use yarn_slinger::prelude::*;
 
+mod extensions;
+mod paths;
 mod step;
 mod test_plan;
 
 pub mod prelude {
-    pub use crate::test_base::{step::*, test_plan::*, *};
+    pub use crate::test_base::{extensions::*, paths::*, step::*, test_plan::*, *};
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct TestBase {
     pub dialogue: Dialogue,
-}
-
-pub fn create_test_node(source: &str) -> String {
-    create_test_node_with_name(source, "Start")
-}
-
-pub fn create_test_node_with_name(source: &str, name: &str) -> String {
-    format!("title: {name}\n---\n{source}\n===")
-}
-
-pub fn project_root_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-pub fn test_data_path() -> PathBuf {
-    let project_root_path = project_root_path();
-    let project_root = project_root_path.to_str().unwrap();
-    [
-        project_root,
-        "..",
-        "..",
-        "third-party",
-        "YarnSpinner",
-        "Tests",
-    ]
-    .iter()
-    .collect()
-}
-
-pub fn space_demo_scripts_path() -> PathBuf {
-    let test_data_path = test_data_path();
-    let test_data = test_data_path.to_str().unwrap();
-    [test_data, "Projects", "Space"].iter().collect()
-}
-
-pub trait CompileResultExt {
-    fn unwrap_pretty(self) -> Compilation;
-}
-
-impl CompileResultExt for Result<Compilation, CompilationError> {
-    fn unwrap_pretty(self) -> Compilation {
-        match self {
-            Ok(compilation) => compilation,
-            Err(error) => {
-                for diagnostic in error.diagnostics {
-                    eprintln!("{}", diagnostic);
-                }
-                panic!("Compilation failed due to Yarn errors")
-            }
-        }
-    }
-}
-
-pub trait TestCompilationJob {
-    fn from_test_source(source: &str) -> Self;
-}
-
-impl TestCompilationJob for CompilationJob {
-    fn from_test_source(source: &str) -> Self {
-        let file = File {
-            file_name: "<input>".to_string(),
-            source: create_test_node(source),
-        };
-
-        Self::default().with_file(file)
-    }
+    pub test_plan: TestPlan,
 }

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -36,7 +36,7 @@ pub struct TestBase {
     pub dialogue: Dialogue,
     test_plan: Arc<RwLock<Option<TestPlan>>>,
     string_table: Arc<RwLock<HashMap<LineId, StringInfo>>>,
-    pub runtime_errors_cause_panic: Arc<AtomicBool>,
+    runtime_errors_cause_panic: Arc<AtomicBool>,
 }
 
 impl Default for TestBase {

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -3,6 +3,8 @@
 use std::path::PathBuf;
 use yarn_slinger::prelude::*;
 
+mod test_plan;
+
 #[derive(Debug, Clone, Default)]
 pub struct TestBase {
     pub dialogue: Dialogue,

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -1,4 +1,10 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestBase.cs>
+//!
+//! ## Implementations notes
+//! Methods used for upgrade testing were not ported since we don't offer any upgrade functionality.
+//! This includes `DirectorySources`.
+//!
+//! Methods for tests we didn't port are also naturally not included. This includes `FormatParseTreeAsText`
 
 // Allowed because this is a common file and not all tests use the methods provided.
 // Everything is actually used, but the checker doesn't recognize it because all integration test files

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -280,15 +280,25 @@ impl TestBase {
     pub fn string_table_mut(&mut self) -> impl DerefMut<Target = HashMap<LineId, StringInfo>> + '_ {
         self.string_table.write().unwrap()
     }
+}
 
-    pub fn storage(&self) -> impl Deref<Target = dyn VariableStorage + Send + Sync> + '_ {
-        self.dialogue.variable_storage()
+impl Deref for TestBase {
+    type Target = Dialogue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.dialogue
     }
+}
 
-    pub fn storage_mut(
-        &mut self,
-    ) -> impl DerefMut<Target = dyn VariableStorage + Send + Sync> + '_ {
-        self.dialogue.variable_storage_mut()
+impl DerefMut for TestBase {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.dialogue
+    }
+}
+
+impl AsRef<Dialogue> for TestBase {
+    fn as_ref(&self) -> &Dialogue {
+        &self.dialogue
     }
 }
 

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -61,7 +61,7 @@ impl Default for TestBase {
                     let id = line.id;
                     let string_table = string_table.read().unwrap();
                     let string_info = string_table.get(&id).unwrap();
-                    let line_number = string_info.line_number;
+                    let _line_number = string_info.line_number;
                     // Can't go on because a handler cannot access the dialogue.
                 })
         };
@@ -122,9 +122,11 @@ impl TestBase {
     }
 
     pub fn get_composed_text_for_line(&self, line: Line) -> String {
-        let string_info = self.string_table.get(&line.id).unwrap();
+        let string_table = self.string_table.read().unwrap();
+        let string_info = string_table.get(&line.id).unwrap();
         let substitutions = line.substitutions.iter().map(|s| s.as_str());
-        let substituted_text = Dialogue::expand_substitutions(&string_info.text, substitutions);
+        let substituted_text =
+            ReadOnlyDialogue::expand_substitutions(&string_info.text, substitutions);
         self.dialogue.parse_markup(&substituted_text)
     }
 }

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -1,9 +1,19 @@
-//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestBase.cs#L49>
+//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestBase.cs>
+
+// Allowed because this is a common file and not all tests use the methods provided.
+// Everything is actually used, but the checker doesn't recognize it because all integration test files
+// are separately compiled as their own crate.
+#![allow(dead_code)]
 
 use std::path::PathBuf;
 use yarn_slinger::prelude::*;
 
+mod step;
 mod test_plan;
+
+pub mod prelude {
+    pub use crate::test_base::{step::*, test_plan::*, *};
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct TestBase {
@@ -37,7 +47,6 @@ pub fn test_data_path() -> PathBuf {
     .collect()
 }
 
-#[allow(dead_code)] // Allowed because this is a common file and not all tests use this method.
 pub fn space_demo_scripts_path() -> PathBuf {
     let test_data_path = test_data_path();
     let test_data = test_data_path.to_str().unwrap();

--- a/crates/yarn_slinger/tests/test_base/mod.rs
+++ b/crates/yarn_slinger/tests/test_base/mod.rs
@@ -205,6 +205,12 @@ impl TestBase {
         self
     }
 
+    pub fn with_runtime_causes_no_failures(self) -> Self {
+        self.runtime_errors_cause_panic
+            .store(false, Ordering::Relaxed);
+        self
+    }
+
     /// Executes the named node, and checks any assertions made during
     /// execution. Fails the test if an assertion made in Yarn fails.
     pub fn run_standard_testcase(&mut self) {

--- a/crates/yarn_slinger/tests/test_base/paths.rs
+++ b/crates/yarn_slinger/tests/test_base/paths.rs
@@ -15,22 +15,9 @@ pub fn project_root_path() -> PathBuf {
 }
 
 pub fn test_data_path() -> PathBuf {
-    let project_root_path = project_root_path();
-    let project_root = project_root_path.to_str().unwrap();
-    [
-        project_root,
-        "..",
-        "..",
-        "third-party",
-        "YarnSpinner",
-        "Tests",
-    ]
-    .iter()
-    .collect()
+    project_root_path().join("../../third-party/YarnSpinner/Tests")
 }
 
 pub fn space_demo_scripts_path() -> PathBuf {
-    let test_data_path = test_data_path();
-    let test_data = test_data_path.to_str().unwrap();
-    [test_data, "Projects", "Space"].iter().collect()
+    test_data_path().join("Projects/Space")
 }

--- a/crates/yarn_slinger/tests/test_base/paths.rs
+++ b/crates/yarn_slinger/tests/test_base/paths.rs
@@ -1,0 +1,36 @@
+//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestBase.cs>
+
+use std::path::PathBuf;
+
+pub fn create_test_node(source: &str) -> String {
+    create_test_node_with_name(source, "Start")
+}
+
+pub fn create_test_node_with_name(source: &str, name: &str) -> String {
+    format!("title: {name}\n---\n{source}\n===")
+}
+
+pub fn project_root_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+pub fn test_data_path() -> PathBuf {
+    let project_root_path = project_root_path();
+    let project_root = project_root_path.to_str().unwrap();
+    [
+        project_root,
+        "..",
+        "..",
+        "third-party",
+        "YarnSpinner",
+        "Tests",
+    ]
+    .iter()
+    .collect()
+}
+
+pub fn space_demo_scripts_path() -> PathBuf {
+    let test_data_path = test_data_path();
+    let test_data = test_data_path.to_str().unwrap();
+    [test_data, "Projects", "Space"].iter().collect()
+}

--- a/crates/yarn_slinger/tests/test_base/step.rs
+++ b/crates/yarn_slinger/tests/test_base/step.rs
@@ -3,6 +3,7 @@
 use reader::*;
 use std::fmt::Debug;
 use std::str::FromStr;
+
 mod reader;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/yarn_slinger/tests/test_base/step.rs
+++ b/crates/yarn_slinger/tests/test_base/step.rs
@@ -1,0 +1,167 @@
+//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestPlan.cs>
+
+use reader::*;
+use std::fmt::Debug;
+use std::str::FromStr;
+mod reader;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Step {
+    pub expected_step_type: ExpectedStepType,
+    pub value: Option<StepValue>,
+    pub expect_option_enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepValue {
+    String(String),
+    Number(usize),
+}
+
+impl Step {
+    pub(crate) fn read(string: &str) -> Self {
+        let mut reader = Reader::new(string);
+        let expected_step_type = reader.read_next::<ExpectedStepType>();
+        let delimiter: String = reader.read_next();
+        assert_eq!(":", delimiter, "Expected ':' after step type");
+
+        match expected_step_type {
+            ExpectedStepType::Line | ExpectedStepType::Option | ExpectedStepType::Command => {
+                let buf = reader.read_to_end();
+                let value = buf.trim();
+
+                // Options whose text ends with " [disabled]"
+                // are expected to be present, but have their
+                // 'allowed' flag set to false
+                if value == "*" {
+                    Self::with_expected_step_type(expected_step_type)
+                } else if expected_step_type == ExpectedStepType::Option
+                    && value.ends_with(" [disabled]")
+                {
+                    Self {
+                        expected_step_type,
+                        value: Some(value.replace(" [disabled]", "").into()),
+                        expect_option_enabled: false,
+                    }
+                } else {
+                    Self::with_expected_step_type(expected_step_type)
+                }
+            }
+            ExpectedStepType::Select => {
+                let value = reader.read_next::<usize>();
+                Self {
+                    expected_step_type,
+                    value: Some(value.into()),
+                    expect_option_enabled: true,
+                }
+            }
+            ExpectedStepType::Stop => Self::with_expected_step_type(expected_step_type),
+        }
+    }
+
+    pub(crate) fn from_line(line: impl Into<String>) -> Self {
+        Self::with_value_and_type(line.into().into(), ExpectedStepType::Line)
+    }
+
+    pub(crate) fn from_option(line: impl Into<String>) -> Self {
+        Self::with_value_and_type(line.into().into(), ExpectedStepType::Option)
+    }
+
+    pub(crate) fn from_command(line: impl Into<String>) -> Self {
+        Self::with_value_and_type(line.into().into(), ExpectedStepType::Command)
+    }
+
+    pub(crate) fn from_select(selection: impl Into<usize>) -> Self {
+        Self::with_value_and_type(selection.into().into(), ExpectedStepType::Select)
+    }
+
+    pub(crate) fn from_stop() -> Self {
+        Self::with_expected_step_type(ExpectedStepType::Stop)
+    }
+
+    fn with_value_and_type(value: StepValue, expected_step_type: ExpectedStepType) -> Self {
+        Self {
+            expected_step_type,
+            value: Some(value),
+            expect_option_enabled: true,
+        }
+    }
+    fn with_expected_step_type(expected_step_type: ExpectedStepType) -> Self {
+        Self {
+            expected_step_type,
+            value: None,
+            expect_option_enabled: true,
+        }
+    }
+}
+
+impl From<String> for StepValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<usize> for StepValue {
+    fn from(value: usize) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl TryInto<String> for StepValue {
+    type Error = ();
+
+    fn try_into(self) -> Result<String, Self::Error> {
+        match self {
+            Self::String(value) => Ok(value),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryInto<usize> for StepValue {
+    type Error = ();
+
+    fn try_into(self) -> Result<usize, Self::Error> {
+        match self {
+            Self::Number(value) => Ok(value),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum ExpectedStepType {
+    // expecting to see this specific line
+    #[default]
+    Line,
+
+    // expecting to see this specific option (if '*' is given,
+    // means 'see an option, don't care about text')
+    Option,
+
+    // expecting options to have been presented; value = the
+    // index to select
+    Select,
+
+    // expecting to see this specific command
+    Command,
+
+    // expecting to stop the test here (this is optional - a
+    // 'stop' at the end of a test plan is assumed)
+    Stop,
+}
+
+impl FromStr for ExpectedStepType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Line" => Ok(Self::Line),
+            "Option" => Ok(Self::Option),
+            "Select" => Ok(Self::Select),
+            "Command" => Ok(Self::Command),
+            "Stop" => Ok(Self::Stop),
+            _ => Err(()),
+        }
+    }
+}

--- a/crates/yarn_slinger/tests/test_base/step/reader.rs
+++ b/crates/yarn_slinger/tests/test_base/step/reader.rs
@@ -1,0 +1,64 @@
+//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestPlan.cs>
+
+use std::fmt::Debug;
+use std::io::Read;
+use std::str::FromStr;
+
+pub(crate) struct Reader<'a> {
+    content: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    pub(crate) fn new(content: &'a str) -> Self {
+        Self {
+            content: content.as_bytes(),
+        }
+    }
+
+    pub(crate) fn read_next<T>(&mut self) -> T
+    where
+        T: FromStr,
+        <T as FromStr>::Err: Debug,
+    {
+        let string = self.read_next_raw();
+        string.parse().unwrap()
+    }
+
+    pub(crate) fn read_to_end(&mut self) -> String {
+        let mut result = String::new();
+        self.content.read_to_string(&mut result).unwrap();
+        result
+    }
+
+    /// Parse the next T from this string, ignoring leading whitespace
+    fn read_next_raw(&mut self) -> String {
+        let mut string = String::new();
+        loop {
+            let Some(character) = self.read_char() else {
+                break;
+            };
+            if character.is_whitespace() {
+                // eat leading whitespace
+                continue;
+            }
+            string.push(character);
+            if let Some(next) = self.peek_char() {
+                if !next.is_alphanumeric() {
+                    break;
+                }
+            }
+        }
+        string
+    }
+
+    fn read_char(&mut self) -> Option<char> {
+        let mut buf = [0u8; 1];
+        let read = self.content.read(&mut buf).unwrap();
+        (read != 0).then_some(buf[0] as char)
+    }
+
+    fn peek_char(&mut self) -> Option<char> {
+        let buf = self.content.first()?;
+        Some(*buf as char)
+    }
+}

--- a/crates/yarn_slinger/tests/test_base/test_plan.rs
+++ b/crates/yarn_slinger/tests/test_base/test_plan.rs
@@ -1,6 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestPlan.cs>
 
-use crate::test_base::prelude::*;
+use crate::prelude::*;
 use std::fs;
 use std::path::Path;
 

--- a/crates/yarn_slinger/tests/test_base/test_plan.rs
+++ b/crates/yarn_slinger/tests/test_base/test_plan.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone)]
+pub struct TestPlan {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum StepType {}

--- a/crates/yarn_slinger/tests/test_base/test_plan.rs
+++ b/crates/yarn_slinger/tests/test_base/test_plan.rs
@@ -20,7 +20,7 @@ pub struct ProcessedOption {
 }
 
 impl TestPlan {
-    pub fn read(path: &Path) -> Self {
+    pub fn read(path: impl AsRef<Path>) -> Self {
         let steps = fs::read_to_string(path)
             .unwrap()
             .lines()
@@ -46,7 +46,7 @@ impl TestPlan {
             // we've now moved past that, so clear the list of expected
             // options.
             self.next_expected_options.clear();
-            self.next_step_value = None;
+            self.next_step_value = Some(StepValue::Number(0));
         }
 
         for current_step in self.steps.iter().skip(self.current_test_plan_step) {

--- a/crates/yarn_slinger/tests/test_base/test_plan.rs
+++ b/crates/yarn_slinger/tests/test_base/test_plan.rs
@@ -1,5 +1,99 @@
-#[derive(Debug, Clone)]
-pub struct TestPlan {}
+//! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/TestPlan.cs>
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum StepType {}
+use crate::test_base::prelude::*;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TestPlan {
+    pub next_expected_step: ExpectedStepType,
+    pub next_expected_options: Vec<ExpectedOption>,
+    pub next_step_value: Option<StepValue>,
+    steps: Vec<Step>,
+    current_test_plan_step: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedOption {
+    pub line: String,
+    pub enabled: bool,
+}
+
+impl TestPlan {
+    pub fn read(path: &Path) -> Self {
+        let steps = fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            // skip commented lines
+            .filter(|line| !line.trim_start().starts_with('#'))
+            // skip empty or blank lines
+            .filter(|line| !line.trim().is_empty())
+            .map(Step::read)
+            .collect();
+        Self {
+            steps,
+            ..Default::default()
+        }
+    }
+
+    pub fn next(&mut self) {
+        // step through the test plan until we hit an expectation to
+        // see a line, option, or command. specifically, we're waiting
+        // to see if we got a Line, Select, Command or Assert step
+        // type.
+        if self.next_expected_step == ExpectedStepType::Select {
+            // our previously-notified task was to select an option.
+            // we've now moved past that, so clear the list of expected
+            // options.
+            self.next_expected_options.clear();
+            self.next_step_value = None;
+        }
+
+        for current_step in self.steps.iter().skip(self.current_test_plan_step) {
+            self.current_test_plan_step += 1;
+            if current_step.expected_step_type == ExpectedStepType::Option {
+                let Some(StepValue::String(line)) = current_step.value.clone() else {
+                    panic!("Expected option line to be a string");
+                };
+
+                self.next_expected_options.push(ExpectedOption {
+                    line,
+                    enabled: current_step.expect_option_enabled,
+                });
+            } else {
+                self.next_expected_step = current_step.expected_step_type;
+                self.next_step_value = current_step.value.clone();
+                return;
+            }
+        }
+
+        // We've fallen off the end of the test plan step list. We
+        // expect a stop here.
+        self.next_expected_step = ExpectedStepType::Stop;
+    }
+
+    pub fn expect_line(mut self, line: impl Into<String>) -> Self {
+        self.steps.push(Step::from_line(line));
+        self
+    }
+
+    pub fn expect_option(mut self, line: impl Into<String>) -> Self {
+        self.steps.push(Step::from_option(line));
+        self
+    }
+
+    pub fn expect_command(mut self, line: impl Into<String>) -> Self {
+        self.steps.push(Step::from_command(line));
+        self
+    }
+
+    pub fn then_select(mut self, selection: impl Into<usize>) -> Self {
+        self.steps.push(Step::from_select(selection));
+        self
+    }
+
+    pub fn expect_stop(mut self) -> Self {
+        self.steps.push(Step::from_stop());
+        self
+    }
+}

--- a/crates/yarn_slinger/tests/test_base/test_plan.rs
+++ b/crates/yarn_slinger/tests/test_base/test_plan.rs
@@ -7,14 +7,14 @@ use std::path::Path;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TestPlan {
     pub next_expected_step: ExpectedStepType,
-    pub next_expected_options: Vec<ExpectedOption>,
+    pub next_expected_options: Vec<ProcessedOption>,
     pub next_step_value: Option<StepValue>,
     steps: Vec<Step>,
     current_test_plan_step: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExpectedOption {
+pub struct ProcessedOption {
     pub line: String,
     pub enabled: bool,
 }
@@ -56,7 +56,7 @@ impl TestPlan {
                     panic!("Expected option line to be a string");
                 };
 
-                self.next_expected_options.push(ExpectedOption {
+                self.next_expected_options.push(ProcessedOption {
                     line,
                     enabled: current_step.expect_option_enabled,
                 });

--- a/crates/yarn_slinger/tests/type_tests.rs
+++ b/crates/yarn_slinger/tests/type_tests.rs
@@ -14,7 +14,7 @@
 //! so the following (fairly useless) test was omitted:
 //! - `TestBuiltinTypesAreEnumerated`
 
-use crate::test_base::*;
+use test_base::prelude::*;
 use yarn_slinger::prelude::*;
 
 mod test_base;


### PR DESCRIPTION
Preparation for #79.
Makes sure that we can call a couple of `Dialogue` methods from handlers. Please note the doc comments I left.