### PR TITLE
Fix options randomly despawning instantly when they appear

### DIFF
--- a/crates/example_dialogue_view/src/lib.rs
+++ b/crates/example_dialogue_view/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ## Inputs
 //!
-//! - Advance the dialogue: press the space bar, left click or tap the screen after the text is done typing.
+//! - Advance the dialogue: press the space bar, enter key, left click or tap the screen after the text is done typing.
 //! - Type out the text faster: Same as above, but hold press before the text is done typing.
 //! - Select an option: press the number key corresponding to the option you want to select or click/tap the option.
 //!

--- a/docs/src/yarn_files/lines.md
+++ b/docs/src/yarn_files/lines.md
@@ -27,5 +27,5 @@ And everyone lived happily ever after.
 ```
 
 If you're running the example in Yarn Slinger, you can advance the dialogue
-by pressing the space bar, clicking the mouse, or tapping the screen. Remember that you can
+by pressing the space bar, enter key, clicking the mouse, or tapping the screen. Remember that you can
 change the Yarn file while the game is running, so no need to restart the program!

--- a/examples/bevy_yarn_slinger/assets/dialogue/hello_world.yarn
+++ b/examples/bevy_yarn_slinger/assets/dialogue/hello_world.yarn
@@ -1,6 +1,6 @@
 title: HelloWorld
 ---
-Hello World! To continue the dialogue, click with your mouse or press the spacebar.
+Hello World! To continue the dialogue, click with your mouse, press the space bar or the enter key.
 These are options. You can select one by clicking on it or pressing the corresponding number on your keyboard.
 -> Some cool option
 -> Some other cool option


### PR DESCRIPTION
The reason is as follows:
- When the dialog is done, a `DialogueCompleteEvent` is sent
- Some processes check the  `DialogueCompleteEvent` to despawn stuff, consuming the event
- However, these checks don't always happen. We might despawn for other reasons.
- Thus, `DialogueCompleteEvent` might accumulate
- Opening a dialog a second time will consume the `DialogueCompleteEvent` of the last dialog, triggering weird behavior.